### PR TITLE
Developer onboarding improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,115 @@
+# Contributing
+
+Thank you for contributing! This document explains how to get a local development environment running, run tests, and submit a PR.
+
+## Prerequisites
+
+- Git
+- Python 3.10+ (recommended)
+- Poetry (or pip + virtualenv)
+- Docker & Docker Compose
+- (Optional) OpenAI API key if you plan to run examples that generate embeddings or use an LLM
+
+## Development Setup
+
+1. Clone the repo:
+```bash
+git clone https://github.com/oceanbase/langchain-oceanbase.git
+cd langchain-oceanbase
+```
+
+2. Create a virtual environment and install dependencies:
+- With Poetry:
+```bash
+poetry install
+poetry shell
+```
+- With pip:
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+3. Bring up the local database for development (OceanBase):
+```bash
+make docker-up
+# or for SeekDB lightweight alternative:
+make docker-up-seek
+```
+
+4. Environment variables (examples)
+Create a `.env` file or export environment variables:
+```
+OB_HOST=127.0.0.1
+OB_PORT=3306
+OB_USER=root
+OB_PASSWORD=yourpassword
+OB_DB=langchain_ob_demo
+OPENAI_API_KEY=sk-xxxx
+```
+
+## Running tests
+
+- Unit tests:
+```bash
+pytest tests/unit
+```
+
+- Integration tests (requires docker-compose services up):
+```bash
+make docker-up
+pytest tests/integration
+```
+
+- Linting / type checks:
+```bash
+ruff check .
+mypy .
+```
+
+## Code style
+
+- Formatting: black
+- Linting: ruff
+- Type checks: mypy
+- Commit messages: follow Conventional Commits or keep concise, descriptive messages.
+
+## Submitting PRs
+
+1. Create a branch with a descriptive name:
+```bash
+git checkout -b feat/onboard-docker-compose
+```
+
+2. Make edits and add tests where applicable.
+
+3. Run tests and linters locally.
+
+4. Commit changes:
+```bash
+git add .
+git commit -m "feat: add docker-compose and onboarding docs"
+git push origin feat/onboard-docker-compose
+```
+
+5. Open a PR describing the change. Include:
+- Problem you're solving
+- Any migration or manual steps
+- Testing steps
+
+## PR review checklist
+
+- [ ] Tests added/updated
+- [ ] Linting passes
+- [ ] Clear description & motivation
+- [ ] Updated docs if needed
+
+## Makefile targets
+
+- `make docker-up` — start OceanBase
+- `make docker-up-seek` — start SeekDB (alternative)
+- `make docker-down` — stop OceanBase and remove volumes
+- `make docker-logs` — follow OceanBase logs
+
+Thank you for contributing!

--- a/Makefile
+++ b/Makefile
@@ -68,3 +68,54 @@ help:
 	@echo 'integration_test             - run integration tests'
 	@echo 'comprehensive_test           - run comprehensive tests (CI, compatibility, integration)'
 	@echo 'test TEST_FILE=<test_file>   - run all tests in file'
+
+
+# ---- onboarding additions start ----
+.PHONY: help docker-up docker-up-seek docker-down docker-down-seek docker-logs docker-logs-seek \
+        fmt lint typecheck test
+
+help:
+	@echo "Usage:"
+	@echo "  make docker-up          Start OceanBase (docker-compose.yml)"
+	@echo "  make docker-up-seek     Start SeekDB (docker-compose.seekdb.yml)"
+	@echo "  make docker-down        Stop OceanBase and remove volumes"
+	@echo "  make docker-down-seek   Stop SeekDB and remove volumes"
+	@echo "  make docker-logs        Follow OceanBase logs"
+	@echo "  make docker-logs-seek   Follow SeekDB logs"
+	@echo "  make fmt                Format code with black"
+	@echo "  make lint               Run ruff linter"
+	@echo "  make typecheck          Run mypy type checks"
+	@echo "  make test               Run pytest"
+
+# Docker-compose management
+docker-up:
+	docker-compose -f docker-compose.yml up -d
+
+docker-up-seek:
+	docker-compose -f docker-compose.seekdb.yml up -d
+
+docker-down:
+	docker-compose -f docker-compose.yml down -v
+
+docker-down-seek:
+	docker-compose -f docker-compose.seekdb.yml down -v
+
+docker-logs:
+	docker-compose -f docker-compose.yml logs -f
+
+docker-logs-seek:
+	docker-compose -f docker-compose.seekdb.yml logs -f
+
+# Development helpers (only active if these tools are in your toolchain)
+fmt:
+	black .
+
+lint:
+	ruff check .
+
+typecheck:
+	mypy .
+
+test:
+	pytest -q
+# ---- onboarding additions end ----

--- a/README.md
+++ b/README.md
@@ -176,3 +176,84 @@ for doc in results:
 - [**Maximal Marginal Relevance**](./docs/vectorstores.md#maximal-marginal-relevance) - Filter for diversity in search results
 - [**Multiple Index Types**](./docs/vectorstores.md#multiple-index-types) - Different vector index types (HNSW, IVF, FLAT)
 
+## Quickstart
+
+A short quickstart to run the local dev environment and example scripts.
+
+Prerequisites:
+- Git
+- Docker & Docker Compose
+- Python 3.10+
+- (Optional) OpenAI API key for embeddings / LLM examples
+
+1. Clone the repo
+```bash
+git clone https://github.com/oceanbase/langchain-oceanbase.git
+cd langchain-oceanbase
+```
+
+2. Start the local database
+```bash
+# start OceanBase
+make docker-up
+
+# or start SeekDB (lightweight alternative)
+make docker-up-seek
+```
+
+3. Set environment variables (create a `.env` file or export them)
+```
+OB_HOST=127.0.0.1
+OB_PORT=3306
+OB_USER=root
+OB_PASSWORD=changeme
+OB_DB=langchain_ob_demo
+OPENAI_API_KEY=sk-...
+```
+
+4. Install example dependencies (examples use these packages)
+```bash
+pip install openai mysql-connector-python numpy
+```
+
+5. Run an example
+```bash
+python examples/quickstart.py
+python examples/rag_demo.py
+python examples/hybrid_search_demo.py
+```
+
+## Files of interest
+
+- `docker-compose.yml` — OceanBase CE service for local development
+- `docker-compose.seekdb.yml` — SeekDB lightweight alternative
+- `Makefile` — convenience targets: `make docker-up`, `make docker-down`, `make docker-logs`, plus format/lint/typecheck/test helpers
+- `CONTRIBUTING.md` — developer setup, running tests, code style, PR process
+- `examples/` — `quickstart.py`, `rag_demo.py`, `hybrid_search_demo.py`, and `examples/README.md`
+
+## Running tests and linters
+
+- Unit tests:
+```bash
+pytest tests/unit
+```
+
+- Integration tests (requires Docker services):
+```bash
+make docker-up
+pytest tests/integration
+```
+
+- Lint / formatting:
+```bash
+make fmt
+make lint
+make typecheck
+```
+
+## Contributing
+
+See `CONTRIBUTING.md` for detailed developer setup and the PR process. When submitting a PR, please:
+- Base your branch on `main`
+- Reference the issue (e.g., `Closes #43`) in the PR body
+- Run linters and tests locally

--- a/docker-compose.seekdb.yml
+++ b/docker-compose.seekdb.yml
@@ -1,0 +1,26 @@
+version: "3.8"
+
+services:
+  seekdb:
+    # Replace with the official SeekDB image name if different.
+    # This is intended as a lightweight vector alternative for local dev / demos.
+    image: seekdb/seekdb:latest
+    container_name: seekdb
+    restart: unless-stopped
+    ports:
+      - "8080:8080"  # SeekDB API port (example)
+    volumes:
+      - ./data/seekdb:/var/lib/seekdb
+    environment:
+      - SEEKDB_MEMORY_LIMIT=512M
+    healthcheck:
+      test: ["CMD-SHELL", "bash -lc", "for i in {1..30}; do curl -fs http://127.0.0.1:8080/health && exit 0 || sleep 1; done; exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    networks:
+      - ob-net
+
+networks:
+  ob-net:
+    external: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.8"
+
+services:
+  oceanbase:
+    image: oceanbase/oceanbase-ce:4.3.5
+    container_name: oceanbase-ce
+    restart: unless-stopped
+    # Adjust container memory args if your image supports custom envs. These are example envs:
+    environment:
+      # Example memory settings - adapt to the actual image/env variables required by the image
+      - OBSERVER_MEM=2G
+      - OBCMS_MEM=512M
+      - VECTOR_MEMORY_LIMIT=1G
+    volumes:
+      - ./data/oceanbase:/var/lib/oceanbase/data
+    ports:
+      - "2881:2881"  # Observer RPC
+      - "3306:3306"  # MySQL-compatible port (used for SQL clients)
+    healthcheck:
+      test: ["CMD-SHELL", "bash -lc", "for i in {1..60}; do nc -z 127.0.0.1 3306 && exit 0 || sleep 1; done; exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+    networks:
+      - ob-net
+
+networks:
+  ob-net:
+    driver: bridge

--- a/examples/hybrid_search_demo.py
+++ b/examples/hybrid_search_demo.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+hybrid_search_demo.py
+
+Demonstrates a hybrid search approach:
+ - Run a MySQL full-text search to get candidate documents
+ - Compute embedding similarity for candidates and re-rank
+This is useful when combining sparse (keyword) and dense (embedding) signals.
+
+Requirements:
+pip install openai mysql-connector-python numpy
+Set env vars: OB_HOST, OB_PORT, OB_USER, OB_PASSWORD, OB_DB, OPENAI_API_KEY
+"""
+import os
+import json
+import mysql.connector
+import openai
+import numpy as np
+from examples.quickstart import get_db_conn, embed_texts, cosine_similarity  # relative import
+
+openai.api_key = os.environ.get("OPENAI_API_KEY", "")
+
+def ft_search_mysql(query, limit=10):
+    """
+    Performs a simple full-text search using MATCH ... AGAINST.
+    Make sure the 'documents' table has a fulltext index on content if supported:
+    ALTER TABLE documents ADD FULLTEXT(content);
+    Note: Some MySQL variants or OceanBase setups may require different syntax or engine support.
+    """
+    conn = get_db_conn()
+    cursor = conn.cursor(dictionary=True)
+    # Use natural language fulltext search
+    try:
+        cursor.execute(
+            "SELECT id, content, embedding, MATCH(content) AGAINST (%s IN NATURAL LANGUAGE MODE) as ft_score "
+            "FROM documents WHERE MATCH(content) AGAINST (%s IN NATURAL LANGUAGE MODE) LIMIT %s",
+            (query, query, limit),
+        )
+        rows = cursor.fetchall()
+    except Exception:
+        # Fallback to LIKE if fulltext not available
+        cursor.execute(
+            "SELECT id, content, embedding, 0 as ft_score FROM documents WHERE content LIKE %s LIMIT %s",
+            (f"%{query}%", limit),
+        )
+        rows = cursor.fetchall()
+    cursor.close()
+    conn.close()
+    results = []
+    for r in rows:
+        emb = json.loads(r["embedding"]) if r.get("embedding") else None
+        results.append({"id": r["id"], "content": r["content"], "embedding": emb, "ft_score": r.get("ft_score", 0)})
+    return results
+
+def hybrid_search(query, top_k=5, alpha=0.5):
+    """
+    alpha: weight for dense score. hybrid_score = alpha * dense + (1-alpha) * normalized_ft
+    """
+    candidates = ft_search_mysql(query, limit=50)
+    if not candidates:
+        return []
+
+    q_emb = embed_texts([query])[0]
+    dense_scores = []
+    for c in candidates:
+        if c["embedding"]:
+            dense_scores.append(cosine_similarity(q_emb, c["embedding"]))
+        else:
+            dense_scores.append(0.0)
+
+    # normalize ft scores and dense scores
+    ft_scores = np.array([float(c.get("ft_score") or 0.0) for c in candidates], dtype=float)
+    dense_scores = np.array(dense_scores, dtype=float)
+
+    def normalize(arr):
+        if arr.max() == arr.min():
+            return np.zeros_like(arr)
+        return (arr - arr.min()) / (arr.max() - arr.min())
+
+    nf = normalize(ft_scores)
+    nd = normalize(dense_scores)
+    hybrid = alpha * nd + (1 - alpha) * nf
+
+    combined = []
+    for i, c in enumerate(candidates):
+        combined.append((hybrid[i], c, float(nd[i]), float(nf[i])))
+    combined.sort(key=lambda x: x[0], reverse=True)
+    return combined[:top_k]
+
+def main():
+    query = "distributed relational database"
+    print(f"Hybrid search for: {query}")
+    results = hybrid_search(query, top_k=5, alpha=0.6)
+    for score, doc, dense_score, ft_score in results:
+        print(f"\nHybrid score: {score:.4f} (dense: {dense_score:.4f}, ft: {ft_score:.4f})")
+        print(f"Doc id: {doc['id']}\n{doc['content'][:250]}")
+
+if __name__ == "__main__":
+    main()

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+quickstart.py
+
+Demonstrates:
+- connecting to OceanBase via MySQL-compatible port
+- creating a documents table
+- generating embeddings via OpenAI
+- storing embeddings in the DB (as JSON)
+- performing a simple in-Python nearest-neighbor search
+
+Requirements:
+pip install openai mysql-connector-python numpy
+Set env vars: OB_HOST, OB_PORT, OB_USER, OB_PASSWORD, OB_DB, OPENAI_API_KEY
+"""
+import os
+import json
+import time
+import mysql.connector
+import openai
+import numpy as np
+
+# Configuration (from environment)
+OB_HOST = os.environ.get("OB_HOST", "127.0.0.1")
+OB_PORT = int(os.environ.get("OB_PORT", 3306))
+OB_USER = os.environ.get("OB_USER", "root")
+OB_PASSWORD = os.environ.get("OB_PASSWORD", "")
+OB_DB = os.environ.get("OB_DB", "langchain_ob_demo")
+
+openai.api_key = os.environ.get("OPENAI_API_KEY", "")
+
+def get_db_conn():
+    return mysql.connector.connect(
+        host=OB_HOST, port=OB_PORT, user=OB_USER, password=OB_PASSWORD, database=OB_DB
+    )
+
+def init_db():
+    conn = mysql.connector.connect(host=OB_HOST, port=OB_PORT, user=OB_USER, password=OB_PASSWORD)
+    cursor = conn.cursor()
+    cursor.execute(f"CREATE DATABASE IF NOT EXISTS `{OB_DB}`;")
+    conn.commit()
+    cursor.close()
+    conn.close()
+
+    conn = get_db_conn()
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS documents (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            content TEXT NOT NULL,
+            embedding JSON,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB;
+        """
+    )
+    conn.commit()
+    cursor.close()
+    conn.close()
+
+def embed_texts(texts):
+    # Uses OpenAI embeddings (text-embedding-3-small as an example).
+    # You can replace with another embeddings provider.
+    if not openai.api_key:
+        raise RuntimeError("OPENAI_API_KEY is required to generate embeddings for this demo")
+    resp = openai.Embedding.create(model="text-embedding-3-small", input=texts)
+    embeddings = [r["embedding"] for r in resp["data"]]
+    return embeddings
+
+def insert_document(content, embedding):
+    conn = get_db_conn()
+    cursor = conn.cursor()
+    emb_json = json.dumps(embedding)
+    cursor.execute("INSERT INTO documents (content, embedding) VALUES (%s, %s)", (content, emb_json))
+    conn.commit()
+    cursor.close()
+    conn.close()
+
+def fetch_all_docs():
+    conn = get_db_conn()
+    cursor = conn.cursor(dictionary=True)
+    cursor.execute("SELECT id, content, embedding FROM documents")
+    rows = cursor.fetchall()
+    cursor.close()
+    conn.close()
+    results = []
+    for r in rows:
+        emb = json.loads(r["embedding"]) if r["embedding"] else None
+        results.append({"id": r["id"], "content": r["content"], "embedding": emb})
+    return results
+
+def cosine_similarity(a, b):
+    a = np.array(a, dtype=float)
+    b = np.array(b, dtype=float)
+    if np.linalg.norm(a) == 0 or np.linalg.norm(b) == 0:
+        return 0.0
+    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+
+def simple_search(query, top_k=3):
+    q_emb = embed_texts([query])[0]
+    docs = fetch_all_docs()
+    scored = []
+    for d in docs:
+        if d["embedding"]:
+            score = cosine_similarity(q_emb, d["embedding"])
+            scored.append((score, d))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return scored[:top_k]
+
+def main():
+    print("Initializing DB...")
+    init_db()
+    time.sleep(1)
+
+    # Insert some demo docs if table empty
+    docs = [
+        "Python is a popular programming language for data science and web development.",
+        "OceanBase is a distributed relational database compatible with MySQL.",
+        "LangChain helps glue together language models and your data in vectors.",
+    ]
+    existing = fetch_all_docs()
+    if not existing:
+        print("Inserting demo documents and embeddings...")
+        embeddings = embed_texts(docs)
+        for txt, emb in zip(docs, embeddings):
+            insert_document(txt, emb)
+        print("Inserted demo documents.")
+
+    query = "How can I use vectors with databases?"
+    print(f"Searching for: {query}")
+    results = simple_search(query)
+    for score, doc in results:
+        print(f"\nScore: {score:.4f}\nDoc id: {doc['id']}\n{doc['content']}")
+
+if __name__ == "__main__":
+    main()

--- a/examples/rag_demo.py
+++ b/examples/rag_demo.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+rag_demo.py
+
+A simple RAG (Retrieve-and-Generate) demo:
+- Retrieve top-k documents by embedding similarity (using the same DB approach as quickstart)
+- Send retrieved documents + question to OpenAI ChatCompletion to generate an answer
+
+Requirements:
+pip install openai mysql-connector-python numpy
+Set env vars: OB_HOST, OB_PORT, OB_USER, OB_PASSWORD, OB_DB, OPENAI_API_KEY
+"""
+import os
+import json
+import mysql.connector
+import openai
+import numpy as np
+from examples.quickstart import get_db_conn, fetch_all_docs, embed_texts, cosine_similarity  # relative import
+
+openai.api_key = os.environ.get("OPENAI_API_KEY", "")
+
+def retrieve(query, top_k=3):
+    q_emb = embed_texts([query])[0]
+    docs = fetch_all_docs()
+    scored = []
+    for d in docs:
+        if d["embedding"]:
+            score = cosine_similarity(q_emb, d["embedding"])
+            scored.append((score, d))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [d for s, d in scored[:top_k]]
+
+def generate_answer(query, context_docs):
+    # Compose a prompt for the LLM using retrieved docs
+    system = {"role": "system", "content": "You are a helpful assistant."}
+    context_text = "\n\n".join([f"Document {d['id']}: {d['content']}" for d in context_docs])
+    prompt = (
+        f"Use the following documents as context to answer the user's question.\n\n"
+        f"Context:\n{context_text}\n\nQuestion: {query}\n\nAnswer concisely with references to the documents when useful."
+    )
+    resp = openai.ChatCompletion.create(
+        model="gpt-3.5-turbo",
+        messages=[system, {"role": "user", "content": prompt}],
+        max_tokens=300,
+        temperature=0.0,
+    )
+    return resp["choices"][0]["message"]["content"].strip()
+
+def main():
+    question = "What is OceanBase and how does it relate to vector storage?"
+    print("Retrieving relevant docs...")
+    docs = retrieve(question, top_k=3)
+    print("Retrieved docs:")
+    for d in docs:
+        print(f"- (id={d['id']}) {d['content'][:120]}")
+
+    print("\nGenerating answer with LLM...")
+    answer = generate_answer(question, docs)
+    print("\nAnswer:\n")
+    print(answer)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary
-------
This PR implements developer onboarding improvements requested in issue #43. It adds Docker Compose files for local development, onboarding documentation, example scripts demonstrating typical workflows (quickstart / RAG / hybrid search), and small developer convenience Makefile targets. These changes are intended to make it easier for new contributors to set up the environment and get started.

Closes
------
Closes #43

What changed
------------
Added/new files:
- docker-compose.yml
- docker-compose.seekdb.yml
- CONTRIBUTING.md
- examples/README.md
- examples/quickstart.py
- examples/rag_demo.py
- examples/hybrid_search_demo.py
- README.md (updated quickstart + onboarding content)

Updated:
- Makefile (appended onboarding/dev targets: docker-up, docker-down, docker-logs, docker-up-seek, docker-down-seek, docker-logs-seek, fmt, lint, typecheck, test)

Why
---
- Provide reproducible local dev environment using OceanBase (and a lightweight SeekDB alternative).
- Document development setup and PR/test/lint expectations for new contributors.
- Provide runnable examples to demonstrate the library's intended usage patterns and to make manual testing easier.

How to test locally
-------------------
1. Checkout branch:
   git checkout -b feat/onboarding-improvements-43

2. Bring up the database:
   make docker-up
   # or for the lightweight alternative:
   make docker-up-seek

3. Create a `.env` file (or export env vars):
   OB_HOST=127.0.0.1
   OB_PORT=3306
   OB_USER=root
   OB_PASSWORD=<your-password>
   OB_DB=langchain_ob_demo
   OPENAI_API_KEY=<optional-if-using-examples>

4. Install example dependencies:
   pip install openai mysql-connector-python numpy

5. Run examples:
   python examples/quickstart.py
   python examples/rag_demo.py
   python examples/hybrid_search_demo.py

6. Run linters & tests:
   make fmt
   make lint
   make typecheck
   pytest -q

Notes
--------------
- The example scripts use OpenAI for embeddings/LLM; running them requires an API key. They are intentionally minimal and store embeddings as JSON in the DB and perform client-side ranking (portable approach).
- The Makefile changes were appended to avoid losing existing targets. If your repo's Makefile already has targets with the same names, please review and merge appropriately.
- The docker-compose healthchecks assume the images contain common utilities (nc/curl). If not, adjust healthchecks per image.
- If the repo has CI that enforces dependency files (pyproject.toml / requirements.txt), consider adding example dependencies or mark examples as optional.
