### PR TITLE
fix: correct dim argument passing in create_table_func

### DIFF
--- a/langchain_oceanbase/vectorstores.py
+++ b/langchain_oceanbase/vectorstores.py
@@ -1060,7 +1060,7 @@ class OceanbaseVectorStore(VectorStore):
 
         # Create table if it doesn't exist
         if not self.obvector.check_table_exists(table_name):
-            create_table_func(embedding_dim=embedding_dim)
+            create_table_func(embedding_dim)
 
         # Generate IDs if not provided
         if ids is None:


### PR DESCRIPTION

## Summary

Error logs before fixing:

```bash
Auto-sync failed for seven_git: OceanbaseVectorStore._create_table_with_index_by_embedding_dim() got an unexpected keyword argument 'embedding_dim'
```

The issue is that `_add_documents_with_hybrid_field` calls `create_table_func(embedding_dim=embedding_dim)`, but the target method [_create_table_with_index_by_embedding_dim(self, dim: int)](https://github.com/oceanbase/langchain-oceanbase/blob/main/langchain_oceanbase/vectorstores.py#L409) expects dim as the parameter name. Changed to a positional argument to resolve the mismatch.

