### PR TITLE
chore: add git-flow governance workflow and docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+
+- problem:
+- solution:
+- validation:
+
+## Git-Flow Check
+
+- [ ] I targeted `develop` for regular work (`feature/*`, `bugfix/*`, `chore/*`, `docs/*`, `refactor/*`, `test/*`)
+- [ ] I targeted `main` only from a `release/*`, `hotfix/*`, or approved maintenance branch
+- [ ] I used a git-flow style branch name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,17 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches:
+      - main
+      - develop
+      - 'release/**'
+      - 'hotfix/**'
   pull_request:
-    branches: [ main, develop ]
+    branches:
+      - main
+      - develop
+      - 'release/**'
+      - 'hotfix/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/gitflow-governance.yml
+++ b/.github/workflows/gitflow-governance.yml
@@ -1,0 +1,68 @@
+name: GitFlow Governance
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited]
+    branches:
+      - main
+      - develop
+      - 'release/**'
+      - 'hotfix/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate:
+    name: GitFlow Governance
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate branch flow
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          allow_main() {
+            case "$1" in
+              release/*|hotfix/*|dependabot/*) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          allow_develop() {
+            case "$1" in
+              feature/*|bugfix/*|chore/*|docs/*|refactor/*|test/*|release/*|hotfix/*|dependabot/*) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          case "$BASE_REF" in
+            main)
+              if allow_main "$HEAD_REF"; then
+                echo "Validated: $HEAD_REF -> $BASE_REF"
+                exit 0
+              fi
+              echo "::error title=Invalid git-flow target::Pull requests into main must come from release/*, hotfix/*, or dependabot/* branches."
+              exit 1
+              ;;
+            develop)
+              if allow_develop "$HEAD_REF"; then
+                echo "Validated: $HEAD_REF -> $BASE_REF"
+                exit 0
+              fi
+              echo "::error title=Invalid git-flow target::Pull requests into develop must come from feature/*, bugfix/*, chore/*, docs/*, refactor/*, test/*, release/*, hotfix/*, or dependabot/* branches."
+              exit 1
+              ;;
+            release/*|hotfix/*)
+              echo "Validated: $HEAD_REF -> $BASE_REF (no extra policy for release/hotfix maintenance branches)"
+              ;;
+            *)
+              echo "::error title=Unsupported base branch::Base branch '$BASE_REF' is outside the configured git-flow policy."
+              exit 1
+              ;;
+          esac

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,23 +77,41 @@ mypy .
 
 ## Submitting PRs
 
-1. Create a branch with a descriptive name:
+1. Start from the correct base branch:
+   - Regular work starts from `develop`
+   - Releases start from `develop`
+   - Hotfixes start from `main`
+
+2. Create a branch with a git-flow style name:
 ```bash
-git checkout -b feat/onboard-docker-compose
+git checkout -b feature/onboard-docker-compose origin/develop
 ```
 
-2. Make edits and add tests where applicable.
+Examples:
+```bash
+git checkout -b bugfix/fix-seekdb-timeout origin/develop
+git checkout -b release/0.3.4 origin/develop
+git checkout -b hotfix/restore-ci origin/main
+```
 
-3. Run tests and linters locally.
+3. Make edits and add tests where applicable.
 
-4. Commit changes:
+4. Run tests and linters locally.
+
+5. Commit changes:
 ```bash
 git add .
 git commit -m "feat: add docker-compose and onboarding docs"
-git push origin feat/onboard-docker-compose
+git push origin feature/onboard-docker-compose
 ```
 
-5. Open a PR describing the change. Include:
+6. Open a PR describing the change. Use these git-flow targets:
+- `feature/*`, `bugfix/*`, `chore/*`, `docs/*`, `refactor/*`, `test/*` -> `develop`
+- `release/*` -> `main`
+- `hotfix/*` -> `main`, then back-merge to `develop`
+- Dependabot PRs may continue to target `main` until `develop` is fully reconciled with the current `main` history
+
+Include:
 - Problem you're solving
 - Any migration or manual steps
 - Testing steps

--- a/README.md
+++ b/README.md
@@ -417,6 +417,8 @@ make lint    # ruff check + mypy
 ## Contributing
 
 See `CONTRIBUTING.md` for detailed developer setup and the PR process. When submitting a PR, please:
-- Base your branch on `main`
+- Target `develop` for regular work (`feature/*`, `bugfix/*`, `chore/*`, `docs/*`, `refactor/*`, `test/*`)
+- Use `release/*` or `hotfix/*` as the normal PR sources into `main`
+- Expect Dependabot maintenance PRs to continue targeting `main` until `develop` is fully reconciled
 - Reference the issue (e.g., `Closes #43`) in the PR body
 - Run linters and tests locally


### PR DESCRIPTION
## What
- add a dedicated GitFlow Governance workflow to validate allowed PR source and target branches
- extend CI to cover release and hotfix branches
- document the branch model in CONTRIBUTING, README, and the PR template

## Why
- move branch policy from tribal knowledge into an enforceable workflow
- prepare the repo for a managed git-flow process without rewriting the current develop history

## Notes
- Dependabot remains allowed into main as an explicit maintenance exception until develop is reconciled with current main history

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to GitHub workflows and contributor documentation; the main impact is potential PR/CI failures if branch naming/targets don’t match the new policy.
> 
> **Overview**
> Adds a **GitFlow governance** GitHub Action (`pull_request_target`) that blocks PRs with invalid source/target branch combinations (e.g., only `release/*`, `hotfix/*`, `dependabot/*` into `main`; git-flow prefixes into `develop`).
> 
> Expands the `CI` workflow triggers to also run on `release/**` and `hotfix/**` branches for both pushes and PRs.
> 
> Updates contributor-facing guidance by adding a PR template section and revising `CONTRIBUTING.md`/`README.md` to document the expected git-flow branching and PR targets (including the Dependabot exception).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83e89206b94d665d3ce5e7674e1c0613dd350f8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->