### PR TITLE
chore: retarget dependabot updates to develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
   # Python dependencies (weekly)
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -37,6 +38,7 @@ updates:
   # GitHub Actions (monthly)
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,8 @@ git push origin feature/onboard-docker-compose
 - `feature/*`, `bugfix/*`, `chore/*`, `docs/*`, `refactor/*`, `test/*` -> `develop`
 - `release/*` -> `main`
 - `hotfix/*` -> `main`, then back-merge to `develop`
-- Dependabot PRs may continue to target `main` until `develop` is fully reconciled with the current `main` history
+- Dependabot version updates target `develop`
+- Dependabot security updates still follow the GitHub default branch until a repo admin switches the default branch from `main` to `develop`
 
 Include:
 - Problem you're solving

--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ make lint    # ruff check + mypy
 See `CONTRIBUTING.md` for detailed developer setup and the PR process. When submitting a PR, please:
 - Target `develop` for regular work (`feature/*`, `bugfix/*`, `chore/*`, `docs/*`, `refactor/*`, `test/*`)
 - Use `release/*` or `hotfix/*` as the normal PR sources into `main`
-- Expect Dependabot maintenance PRs to continue targeting `main` until `develop` is fully reconciled
+- Dependabot version updates now target `develop`
+- Dependabot security updates still follow the GitHub default branch until a repo admin switches the default branch from `main` to `develop`
 - Reference the issue (e.g., `Closes #43`) in the PR body
 - Run linters and tests locally


### PR DESCRIPTION
## What
- retarget Dependabot version updates to `develop`
- update contributor docs to reflect the new branch routing
- document that security updates still follow the GitHub default branch until an admin flips it to `develop`

## Why
- `develop` now matches current `main`, so it can act as the integration branch for routine update traffic
- this moves most automated maintenance toward the intended git-flow path even before the GitHub default branch is switched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: configuration/docs-only change that just redirects Dependabot PR targets; no runtime code paths are modified.
> 
> **Overview**
> Dependabot is reconfigured to open both `pip` and `github-actions` version-update PRs against `develop` via `target-branch` in `.github/dependabot.yml`.
> 
> Contributor guidance in `CONTRIBUTING.md` and `README.md` is updated to reflect that **Dependabot version updates go to `develop`**, while **security updates remain on the GitHub default branch** until it’s switched to `develop`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a69ba71c5e3031c08d7a72e83b61a785973f2c3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->