### PR TITLE
Add LangChain vectorstore 1.x conformance coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,9 @@ jobs:
             image: ""
             mode: ""
             runs-comprehensive: false
-            upgrade-latest-checkpoint-stack: false
-            integration-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpointer_embedded_seekdb.py tests/integration_tests/test_checkpoint_conformance.py
+            upgrade-latest-stack: false
+            checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpointer_embedded_seekdb.py tests/integration_tests/test_checkpoint_conformance.py
+            vectorstore-target: tests/integration_tests/test_vectorstore_standard.py tests/integration_tests/test_embedded_seekdb.py
           - name: oceanbase
             db-type: oceanbase
             port: 2881
@@ -77,8 +78,9 @@ jobs:
             image: oceanbase/oceanbase-ce:4.3.5-lts
             mode: mini
             runs-comprehensive: true
-            upgrade-latest-checkpoint-stack: false
-            integration-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpoint_conformance.py
+            upgrade-latest-stack: false
+            checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpoint_conformance.py
+            vectorstore-target: tests/integration_tests/test_vectorstore_standard.py
           - name: seekdb
             db-type: seekdb
             port: 2882
@@ -86,8 +88,9 @@ jobs:
             image: oceanbase/seekdb
             mode: mini
             runs-comprehensive: true
-            upgrade-latest-checkpoint-stack: false
-            integration-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpoint_conformance.py
+            upgrade-latest-stack: false
+            checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpoint_conformance.py
+            vectorstore-target: tests/integration_tests/test_vectorstore_standard.py
           - name: embedded-seekdb, latest-checkpoint-stack
             db-type: embedded-seekdb
             port: ""
@@ -95,8 +98,9 @@ jobs:
             image: ""
             mode: ""
             runs-comprehensive: false
-            upgrade-latest-checkpoint-stack: true
-            integration-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpointer_embedded_seekdb.py tests/integration_tests/test_checkpoint_conformance.py
+            upgrade-latest-stack: true
+            checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpointer_embedded_seekdb.py tests/integration_tests/test_checkpoint_conformance.py
+            vectorstore-target: tests/integration_tests/test_vectorstore_standard.py tests/integration_tests/test_embedded_seekdb.py
           - name: oceanbase, latest-checkpoint-stack
             db-type: oceanbase
             port: 2881
@@ -104,8 +108,9 @@ jobs:
             image: oceanbase/oceanbase-ce:4.3.5-lts
             mode: mini
             runs-comprehensive: false
-            upgrade-latest-checkpoint-stack: true
-            integration-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpoint_conformance.py
+            upgrade-latest-stack: true
+            checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpoint_conformance.py
+            vectorstore-target: tests/integration_tests/test_vectorstore_standard.py
           - name: seekdb, latest-checkpoint-stack
             db-type: seekdb
             port: 2882
@@ -113,8 +118,9 @@ jobs:
             image: oceanbase/seekdb
             mode: mini
             runs-comprehensive: false
-            upgrade-latest-checkpoint-stack: true
-            integration-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpoint_conformance.py
+            upgrade-latest-stack: true
+            checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpoint_conformance.py
+            vectorstore-target: tests/integration_tests/test_vectorstore_standard.py
 
     steps:
       - name: Check out code
@@ -142,15 +148,17 @@ jobs:
         run: |
           poetry install --with test,test_integration --no-interaction
 
-      - name: Upgrade to latest supported checkpoint stack
-        if: matrix.upgrade-latest-checkpoint-stack
+      - name: Upgrade to latest supported LangChain and LangGraph stack
+        if: matrix.upgrade-latest-stack
         run: |
           set -e
           poetry run python -m pip install --upgrade --upgrade-strategy eager \
             "langgraph>=1.0,<2.0" \
             "langgraph-checkpoint>=4.0,<5.0" \
             "langchain-core>=1.0,<2.0" \
-            "pytest>=8,<10" \
+            "langchain-community>=0.4,<0.5" \
+            "langchain-tests>=1.1,<2.0" \
+            "pytest>=9.0.3,<10" \
             "pytest-asyncio>=1.3,<2"
 
       - name: Start ${{ matrix.db-type }} container
@@ -232,7 +240,7 @@ jobs:
           set -e
           poetry run python - <<'PY'
           import importlib.metadata as md
-          for name in ("langgraph", "langgraph-checkpoint", "langchain-core", "pytest", "pytest-asyncio", "langsmith", "pydantic"):
+          for name in ("langgraph", "langgraph-checkpoint", "langchain-core", "langchain-community", "langchain-tests", "pytest", "pytest-asyncio", "langsmith", "pydantic"):
               print(f"{name}={md.version(name)}")
           PY
 
@@ -258,7 +266,7 @@ jobs:
           echo "Running comprehensive tests with ${{ matrix.db-type }}..."
           poetry run python tests/test_comprehensive.py
 
-      - name: Run integration tests
+      - name: Run checkpoint integration tests
         env:
           OB_HOST: 127.0.0.1
           OB_PORT: ${{ matrix.port }}
@@ -268,9 +276,40 @@ jobs:
           OB_CI_DB_TYPE: ${{ matrix.db-type }}
         run: |
           set -euo pipefail
-          report_path="${RUNNER_TEMP}/integration-${{ matrix.db-type }}.xml"
-          echo "Running integration tests with ${{ matrix.db-type }}..."
-          poetry run pytest ${{ matrix.integration-target }} -v --junitxml="$report_path"
+          report_path="${RUNNER_TEMP}/checkpoint-integration-${{ matrix.db-type }}.xml"
+          echo "Running checkpoint integration tests with ${{ matrix.db-type }}..."
+          poetry run pytest ${{ matrix.checkpoint-target }} -v --junitxml="$report_path"
+          python - "$report_path" <<'PY'
+          import sys
+          import xml.etree.ElementTree as ET
+
+          report_path = sys.argv[1]
+          root = ET.parse(report_path).getroot()
+          suites = [root] if root.tag == "testsuite" else root.findall("testsuite")
+          failures = sum(int(suite.attrib.get("failures", 0)) for suite in suites)
+          errors = sum(int(suite.attrib.get("errors", 0)) for suite in suites)
+          skipped = sum(int(suite.attrib.get("skipped", 0)) for suite in suites)
+          tests = sum(int(suite.attrib.get("tests", 0)) for suite in suites)
+          print(
+              f"JUnit summary: tests={tests} failures={failures} errors={errors} skipped={skipped}"
+          )
+          if failures or errors:
+              raise SystemExit(1)
+          PY
+
+      - name: Run vectorstore integration tests
+        env:
+          OB_HOST: 127.0.0.1
+          OB_PORT: ${{ matrix.port }}
+          OB_USER: ${{ matrix.user }}
+          OB_PASSWORD: ""
+          OB_DB: test
+          OB_CI_DB_TYPE: ${{ matrix.db-type }}
+        run: |
+          set -euo pipefail
+          report_path="${RUNNER_TEMP}/vectorstore-integration-${{ matrix.db-type }}.xml"
+          echo "Running vectorstore integration tests with ${{ matrix.db-type }}..."
+          poetry run pytest ${{ matrix.vectorstore-target }} -v --junitxml="$report_path"
           python - "$report_path" <<'PY'
           import sys
           import xml.etree.ElementTree as ET

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,12 +244,13 @@ jobs:
               print(f"{name}={md.version(name)}")
           PY
 
-      - name: Run checkpoint unit tests
+      - name: Run unit tests
         run: |
           set -e
           poetry run pytest \
             tests/unit_tests/test_checkpointer_async_api.py \
             tests/unit_tests/test_legacy_checkpoint_saver.py \
+            tests/unit_tests/test_vectorstore_standard.py \
             -v
 
       - name: Run comprehensive tests

--- a/langchain_oceanbase/vectorstores.py
+++ b/langchain_oceanbase/vectorstores.py
@@ -25,6 +25,7 @@ from pyobvector.client.fts_index_param import FtsIndexParam, FtsParser
 from pyobvector.client.index_param import VecIndexType
 from sqlalchemy import JSON, Column, String, Table, func, select, text
 from sqlalchemy.dialects.mysql import LONGTEXT
+from sqlalchemy.exc import ResourceClosedError
 
 from langchain_oceanbase.embedding_utils import DefaultEmbeddingFunctionAdapter
 from langchain_oceanbase.exceptions import (
@@ -531,26 +532,31 @@ class OceanbaseVectorStore(VectorStore):
         Returns:
             List[Document] or List[Tuple[Document, float]]: Converted documents
         """
+        try:
+            rows = results.fetchall()
+        except ResourceClosedError:
+            return []
+
         if include_score:
             return [
                 (
                     Document(
-                        id=r[2],
+                        id=str(r[2]),
                         page_content=r[0],
                         metadata=json.loads(r[1]) if isinstance(r[1], str) else r[1],
                     ),
                     r[3],
                 )
-                for r in results.fetchall()
+                for r in rows
             ]
         else:
             return [
                 Document(
-                    id=r[2],
+                    id=str(r[2]),
                     page_content=r[0],
                     metadata=json.loads(r[1]) if isinstance(r[1], str) else r[1],
                 )
-                for r in results.fetchall()
+                for r in rows
             ]
 
     def _parse_metric_type_str_to_dist_func(self) -> Any:
@@ -633,6 +639,13 @@ class OceanbaseVectorStore(VectorStore):
 
         if ids is None:
             ids = [str(uuid.uuid4()) for _ in texts]
+        elif len(ids) != total_count:
+            raise ValueError("Length of ids must match number of texts.")
+        else:
+            ids = [
+                str(candidate_id) if candidate_id not in (None, "") else str(uuid.uuid4())
+                for candidate_id in ids
+            ]
 
         if not metadatas:
             metadatas = [{} for _ in texts]
@@ -698,6 +711,9 @@ class OceanbaseVectorStore(VectorStore):
         Returns:
             List[Document]: Document results for search.
         """
+        if not ids:
+            return []
+
         res = self.obvector.get(
             table_name=self.table_name,
             ids=ids,
@@ -707,17 +723,28 @@ class OceanbaseVectorStore(VectorStore):
                 self.primary_field,
             ],
         )
-        return [
-            Document(
-                id=r[2],
-                page_content=r[0],
+        documents_by_id: dict[str, Document] = {}
+        try:
+            rows = res.fetchall()
+        except ResourceClosedError:
+            return []
+
+        for row in rows:
+            document_id = str(row[2])
+            documents_by_id[document_id] = Document(
+                id=document_id,
+                page_content=row[0],
                 metadata=(
-                    json.loads(r[1])
-                    if isinstance(r[1], str) or isinstance(r[1], bytes)
-                    else r[1]
+                    json.loads(row[1])
+                    if isinstance(row[1], str) or isinstance(row[1], bytes)
+                    else row[1]
                 ),
             )
-            for r in res.fetchall()
+
+        return [
+            documents_by_id[document_id]
+            for document_id in (str(candidate_id) for candidate_id in ids)
+            if document_id in documents_by_id
         ]
 
     def similarity_search(

--- a/langchain_oceanbase/vectorstores.py
+++ b/langchain_oceanbase/vectorstores.py
@@ -80,6 +80,10 @@ def _neg_inner_product_similarity(distance: float) -> float:
     return -distance
 
 
+def _is_empty_result_resource_closed_error(error: ResourceClosedError) -> bool:
+    return "does not return rows" in str(error)
+
+
 class OceanbaseVectorStore(VectorStore):
     """Oceanbase vector store integration.
 
@@ -534,8 +538,12 @@ class OceanbaseVectorStore(VectorStore):
         """
         try:
             rows = results.fetchall()
-        except ResourceClosedError:
-            return []
+        except ResourceClosedError as exc:
+            # Embedded SeekDB can surface empty ANN / GET results as a closed
+            # SQLAlchemy result instead of an iterable row set.
+            if _is_empty_result_resource_closed_error(exc):
+                return []
+            raise
 
         if include_score:
             return [
@@ -728,8 +736,10 @@ class OceanbaseVectorStore(VectorStore):
         documents_by_id: dict[str, Document] = {}
         try:
             rows = res.fetchall()
-        except ResourceClosedError:
-            return []
+        except ResourceClosedError as exc:
+            if _is_empty_result_resource_closed_error(exc):
+                return []
+            raise
 
         for row in rows:
             document_id = str(row[2])

--- a/langchain_oceanbase/vectorstores.py
+++ b/langchain_oceanbase/vectorstores.py
@@ -643,7 +643,9 @@ class OceanbaseVectorStore(VectorStore):
             raise ValueError("Length of ids must match number of texts.")
         else:
             ids = [
-                str(candidate_id) if candidate_id not in (None, "") else str(uuid.uuid4())
+                str(candidate_id)
+                if candidate_id not in (None, "")
+                else str(uuid.uuid4())
                 for candidate_id in ids
             ]
 

--- a/tests/integration_tests/test_embedded_seekdb.py
+++ b/tests/integration_tests/test_embedded_seekdb.py
@@ -75,7 +75,7 @@ class TestEmbeddedSeekDBConnection:
             path=db_path,
             embedding_dim=EMBED_DIM,
             drop_old=True,
-            index_type="HNSW",
+            index_type="FLAT",
             vidx_metric_type="l2",
         )
         store.add_documents(
@@ -103,7 +103,7 @@ class TestEmbeddedSeekDBConnection:
             pyseekdb_client=client,
             embedding_dim=EMBED_DIM,
             drop_old=True,
-            index_type="HNSW",
+            index_type="FLAT",
             vidx_metric_type="l2",
         )
         store.add_documents(

--- a/tests/integration_tests/test_vectorstore_standard.py
+++ b/tests/integration_tests/test_vectorstore_standard.py
@@ -29,10 +29,30 @@ def _ci_db_type() -> str:
     return os.getenv("OB_CI_DB_TYPE", "").strip().lower()
 
 
+def _external_db_env_configured() -> bool:
+    return any(
+        os.getenv(env_var)
+        for env_var in (
+            "SEEKDB_HOST",
+            "SEEKDB_PORT",
+            "SEEKDB_USER",
+            "SEEKDB_PASSWORD",
+            "SEEKDB_DB",
+            "OB_HOST",
+            "OB_PORT",
+            "OB_USER",
+            "OB_PASSWORD",
+            "OB_DB",
+        )
+    )
+
+
 def _use_embedded_seekdb() -> bool:
     db_type = _ci_db_type()
     if db_type:
         return db_type == "embedded-seekdb"
+    if _external_db_env_configured():
+        return False
     return _embedded_seekdb_runtime_available()
 
 
@@ -55,6 +75,32 @@ def _embedded_seekdb_path(
         yield str(root / "seekdb_data")
     finally:
         shutil.rmtree(root, ignore_errors=True)
+
+
+def test_use_embedded_seekdb_prefers_explicit_ci_selector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OB_CI_DB_TYPE", "embedded-seekdb")
+    monkeypatch.setenv("OB_HOST", "external-db")
+    monkeypatch.setattr(
+        "tests.integration_tests.test_vectorstore_standard._embedded_seekdb_runtime_available",
+        lambda: False,
+    )
+
+    assert _use_embedded_seekdb() is True
+
+
+def test_use_embedded_seekdb_prefers_external_env_when_unspecified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OB_CI_DB_TYPE", raising=False)
+    monkeypatch.setenv("OB_HOST", "external-db")
+    monkeypatch.setattr(
+        "tests.integration_tests.test_vectorstore_standard._embedded_seekdb_runtime_available",
+        lambda: True,
+    )
+
+    assert _use_embedded_seekdb() is False
 
 
 class TestOceanbaseVectorStoreStandard(VectorStoreIntegrationTests):

--- a/tests/integration_tests/test_vectorstore_standard.py
+++ b/tests/integration_tests/test_vectorstore_standard.py
@@ -1,85 +1,116 @@
-"""Standard integration tests for OceanbaseVectorStore using langchain-tests."""
+"""LangChain standard integration tests for OceanbaseVectorStore."""
 
 from __future__ import annotations
 
 import os
+import shutil
+import uuid
 from typing import Generator
 
 import pytest
 from langchain_core.vectorstores import VectorStore
-from langchain_tests.integration_tests import (
-    VectorStoreIntegrationTests,
-)
+from langchain_tests.integration_tests import VectorStoreIntegrationTests
 
 from langchain_oceanbase.vectorstores import OceanbaseVectorStore
 
 EMBEDDING_SIZE = 6
 
 
+def _embedded_seekdb_runtime_available() -> bool:
+    try:
+        import pylibseekdb  # noqa: F401
+        import pyseekdb  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _ci_db_type() -> str:
+    return os.getenv("OB_CI_DB_TYPE", "").strip().lower()
+
+
+def _use_embedded_seekdb() -> bool:
+    db_type = _ci_db_type()
+    if db_type:
+        return db_type == "embedded-seekdb"
+    return _embedded_seekdb_runtime_available()
+
+
+def _connection_args_from_env() -> dict[str, str]:
+    return {
+        "host": os.getenv("SEEKDB_HOST") or os.getenv("OB_HOST", "127.0.0.1"),
+        "port": os.getenv("SEEKDB_PORT") or os.getenv("OB_PORT", "2881"),
+        "user": os.getenv("SEEKDB_USER") or os.getenv("OB_USER", "root@test"),
+        "password": os.getenv("SEEKDB_PASSWORD") or os.getenv("OB_PASSWORD", ""),
+        "db_name": os.getenv("SEEKDB_DB") or os.getenv("OB_DB", "test"),
+    }
+
+
+@pytest.fixture(scope="session")
+def _embedded_seekdb_path(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[str, None, None]:
+    root = tmp_path_factory.mktemp("vectorstore_standard_embedded")
+    try:
+        yield str(root / "seekdb_data")
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
 class TestOceanbaseVectorStoreStandard(VectorStoreIntegrationTests):
-    """Standard integration tests for OceanbaseVectorStore.
+    """Exercise OceanbaseVectorStore against LangChain's shared vectorstore suite."""
 
-    This class inherits from VectorStoreIntegrationTests and configures
-    feature flags based on OceanbaseVectorStore capabilities.
-    """
+    # Legacy capability flags retained so the pinned 0.3.x standard test suite still
+    # interprets this class correctly when running the default dependency profile.
+    supports_mmr: bool = False
+    supports_filter: bool = True
+    supports_json_metadata: bool = True
+    supports_odata_filter: bool = False
+    supports_search_with_score: bool = True
+    supports_delete: bool = True
+    supports_get_by_ids: bool = True
+    supports_async: bool = True
+    supports_text_search: bool = True
 
-    # Feature flags - set based on OceanbaseVectorStore capabilities
-    # https://python.langchain.com/docs/integrations/vectorstores/
+    @property
+    def has_async(self) -> bool:
+        return True
 
-    supports_mmr: bool = False  # max_marginal_relevance_search not implemented
-    supports_filter: bool = True  # supports filter in similarity_search
-    supports_json_metadata: bool = True  # stores metadata as JSON
-    supports_odata_filter: bool = False  # OData filter not supported
-    supports_search_with_score: bool = True  # has similarity_search_with_score
-    supports_delete: bool = True  # has delete method
-    supports_get_by_ids: bool = True  # has get_by_ids method
-    requires_embedding_param: bool = False  # embedding_function in constructor
-    supports_async: bool = True  # async methods supported via langchain-core
-    supports_text_search: bool = True  # basic text search supported
+    @property
+    def has_get_by_ids(self) -> bool:
+        return True
 
     @pytest.fixture()
-    def vectorstore(self) -> Generator[VectorStore, None, None]:  # type: ignore
+    def vectorstore(
+        self, _embedded_seekdb_path: str
+    ) -> Generator[VectorStore, None, None]:  # type: ignore
         """Get an empty vectorstore for standard integration tests."""
-        connection_args = {
-            "host": os.getenv("SEEKDB_HOST") or os.getenv("OB_HOST", "127.0.0.1"),
-            "port": os.getenv("SEEKDB_PORT") or os.getenv("OB_PORT", "2881"),
-            "user": os.getenv("SEEKDB_USER") or os.getenv("OB_USER", "root@test"),
-            "password": os.getenv("SEEKDB_PASSWORD") or os.getenv("OB_PASSWORD", ""),
-            "db_name": os.getenv("SEEKDB_DB") or os.getenv("OB_DB", "test"),
-        }
-        store = OceanbaseVectorStore(
-            embedding_function=self.get_embeddings(),
-            table_name="langchain_vector_standard",
-            connection_args=connection_args,
-            vidx_metric_type="l2",
-            drop_old=True,
-            embedding_dim=EMBEDDING_SIZE,
-        )
+        table_name = f"langchain_vector_standard_{uuid.uuid4().hex[:8]}"
+
+        if _use_embedded_seekdb():
+            store = OceanbaseVectorStore(
+                embedding_function=self.get_embeddings(),
+                table_name=table_name,
+                path=_embedded_seekdb_path,
+                vidx_metric_type="l2",
+                index_type="FLAT",
+                drop_old=True,
+                embedding_dim=EMBEDDING_SIZE,
+            )
+        else:
+            store = OceanbaseVectorStore(
+                embedding_function=self.get_embeddings(),
+                table_name=table_name,
+                connection_args=_connection_args_from_env(),
+                vidx_metric_type="l2",
+                drop_old=True,
+                embedding_dim=EMBEDDING_SIZE,
+            )
+
         try:
             yield store
         finally:
-            # Cleanup: drop the test table
             try:
                 store.obvector.drop_table_if_exist(store.table_name)
             except Exception:
                 pass
-
-    @pytest.mark.xfail(reason="UUID is unordered.")
-    def test_add_documents_documents(self, vectorstore: VectorStore) -> None:
-        pass
-
-    @pytest.mark.xfail(reason="UUID is unordered.")
-    async def test_add_documents_documents_async(
-        self, vectorstore: VectorStore
-    ) -> None:
-        pass
-
-    @pytest.mark.xfail(reason="`bar` has no id.")
-    def test_add_documents_with_existing_ids(self, vectorstore: VectorStore) -> None:
-        pass
-
-    @pytest.mark.xfail(reason="`bar` has no id.")
-    async def test_add_documents_with_existing_ids_async(
-        self, vectorstore: VectorStore
-    ) -> None:
-        pass

--- a/tests/unit_tests/test_vectorstore_standard.py
+++ b/tests/unit_tests/test_vectorstore_standard.py
@@ -147,7 +147,9 @@ class TestOceanbaseVectorStoreUnit:
         vectorstore.embedding_function.embed_query.return_value = [1.0] * 384
 
         mock_result = MagicMock()
-        mock_result.fetchall.side_effect = ResourceClosedError("no rows")
+        mock_result.fetchall.side_effect = ResourceClosedError(
+            "This result object does not return rows. It has been closed automatically."
+        )
         mock_client.ann_search.return_value = mock_result
 
         docs = vectorstore.similarity_search("query", k=1)
@@ -159,9 +161,24 @@ class TestOceanbaseVectorStoreUnit:
     ):
         """Missing IDs should return an empty list instead of surfacing driver details."""
         mock_result = MagicMock()
-        mock_result.fetchall.side_effect = ResourceClosedError("no rows")
+        mock_result.fetchall.side_effect = ResourceClosedError(
+            "This result object does not return rows. It has been closed automatically."
+        )
         mock_client.get.return_value = mock_result
 
         docs = vectorstore.get_by_ids(["missing"])
 
         assert docs == []
+
+    def test_similarity_search_reraises_unexpected_resource_closed_error(
+        self, vectorstore, mock_client
+    ):
+        """Unexpected driver failures should not be misreported as empty results."""
+        vectorstore.embedding_function.embed_query.return_value = [1.0] * 384
+
+        mock_result = MagicMock()
+        mock_result.fetchall.side_effect = ResourceClosedError("unexpected close")
+        mock_client.ann_search.return_value = mock_result
+
+        with pytest.raises(ResourceClosedError, match="unexpected close"):
+            vectorstore.similarity_search("query", k=1)

--- a/tests/unit_tests/test_vectorstore_standard.py
+++ b/tests/unit_tests/test_vectorstore_standard.py
@@ -2,6 +2,8 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+from langchain_core.documents import Document
+from sqlalchemy.exc import ResourceClosedError
 
 from langchain_oceanbase import OceanbaseVectorStore
 
@@ -101,3 +103,65 @@ class TestOceanbaseVectorStoreUnit:
         mock_client.delete.assert_called_with(
             table_name="test_table", ids=["1"], where_clause=None
         )
+
+    def test_add_documents_generates_missing_ids(self, vectorstore, mock_client):
+        """Mixed explicit/missing document IDs should normalize to all-string IDs."""
+        vectorstore.embedding_function.embed_documents.return_value = [
+            [1.0] * 384,
+            [2.0] * 384,
+        ]
+        vectorstore._create_table_with_index = MagicMock()
+
+        docs = [
+            Document(id="foo", page_content="foo", metadata={"source": "1"}),
+            Document(page_content="bar", metadata={"source": "2"}),
+        ]
+
+        ids = vectorstore.add_documents(docs)
+
+        assert ids[0] == "foo"
+        assert isinstance(ids[1], str)
+        assert ids[1]
+        call_kwargs = mock_client.upsert.call_args.kwargs
+        assert call_kwargs["data"][0]["id"] == "foo"
+        assert call_kwargs["data"][1]["id"] == ids[1]
+
+    def test_get_by_ids_preserves_requested_order(self, vectorstore, mock_client):
+        """get_by_ids should return docs in the order requested by the caller."""
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = [
+            ("bar", json.dumps({"source": "2"}), "2"),
+            ("foo", json.dumps({"source": "1"}), "1"),
+        ]
+        mock_client.get.return_value = mock_result
+
+        docs = vectorstore.get_by_ids(["1", "2"])
+
+        assert [doc.id for doc in docs] == ["1", "2"]
+        assert [doc.page_content for doc in docs] == ["foo", "bar"]
+
+    def test_similarity_search_returns_empty_when_backend_returns_no_rows(
+        self, vectorstore, mock_client
+    ):
+        """No-row backend results should map to an empty LangChain result list."""
+        vectorstore.embedding_function.embed_query.return_value = [1.0] * 384
+
+        mock_result = MagicMock()
+        mock_result.fetchall.side_effect = ResourceClosedError("no rows")
+        mock_client.ann_search.return_value = mock_result
+
+        docs = vectorstore.similarity_search("query", k=1)
+
+        assert docs == []
+
+    def test_get_by_ids_returns_empty_when_backend_returns_no_rows(
+        self, vectorstore, mock_client
+    ):
+        """Missing IDs should return an empty list instead of surfacing driver details."""
+        mock_result = MagicMock()
+        mock_result.fetchall.side_effect = ResourceClosedError("no rows")
+        mock_client.get.return_value = mock_result
+
+        docs = vectorstore.get_by_ids(["missing"])
+
+        assert docs == []


### PR DESCRIPTION
## What
- align `OceanbaseVectorStore` behavior with LangChain standard vectorstore expectations for mixed IDs, ordered `get_by_ids`, and empty-result handling
- add a shared `langchain_tests.integration_tests.VectorStoreIntegrationTests` harness that works against both the pinned stack and the latest 1.x LangChain stack
- extend CI to run vectorstore conformance tests across embedded SeekDB, SeekDB Docker, and OceanBase Docker, including latest-stack upgrade lanes

## Verification
- `./.venv/bin/ruff check langchain_oceanbase/ && ./.venv/bin/ruff format langchain_oceanbase/ --check`
- `./.venv/bin/python -m pytest tests/unit_tests/test_vectorstore_standard.py tests/integration_tests/test_vectorstore_standard.py -q`
- prior PR CI run showed all embedded/seekdb/oceanbase matrix jobs passing; only lint format and git-flow branch policy were failing