### PR TITLE
Add MySQL checkpoint saver compatibility coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,16 @@ jobs:
             upgrade-latest-stack: false
             checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpoint_conformance.py
             vectorstore-target: tests/integration_tests/test_vectorstore_standard.py
+          - name: mysql
+            db-type: mysql
+            port: 3306
+            user: root
+            image: mysql:8.4
+            mode: ""
+            runs-comprehensive: false
+            upgrade-latest-stack: false
+            checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpointer_mysql.py tests/integration_tests/test_checkpoint_conformance.py
+            vectorstore-target: ""
           - name: embedded-seekdb, latest-checkpoint-stack
             db-type: embedded-seekdb
             port: ""
@@ -121,6 +131,16 @@ jobs:
             upgrade-latest-stack: true
             checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpoint_conformance.py
             vectorstore-target: tests/integration_tests/test_vectorstore_standard.py
+          - name: mysql, latest-checkpoint-stack
+            db-type: mysql
+            port: 3306
+            user: root
+            image: mysql:8.4
+            mode: ""
+            runs-comprehensive: false
+            upgrade-latest-stack: true
+            checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpointer_mysql.py tests/integration_tests/test_checkpoint_conformance.py
+            vectorstore-target: ""
 
     steps:
       - name: Check out code
@@ -162,7 +182,7 @@ jobs:
             "pytest-asyncio>=1.3,<2"
 
       - name: Start ${{ matrix.db-type }} container
-        if: matrix.image != ''
+        if: matrix.image != '' && matrix.db-type != 'mysql'
         run: |
           set -e
           echo "Starting ${{ matrix.db-type }} container..."
@@ -171,6 +191,19 @@ jobs:
             -p ${{ matrix.port }}:2881 \
             ${{ matrix.image }}
           echo "${{ matrix.db-type }} container started"
+
+      - name: Start mysql container
+        if: matrix.db-type == 'mysql'
+        run: |
+          set -e
+          echo "Starting mysql container..."
+          docker run -d --name "langchain_mysql_test" \
+            -e MYSQL_ROOT_PASSWORD=rootpass \
+            -e MYSQL_DATABASE=test \
+            -e MYSQL_ROOT_HOST=% \
+            -p ${{ matrix.port }}:3306 \
+            ${{ matrix.image }}
+          echo "mysql container started"
 
       # OceanBase: wait for "boot success!"
       - name: Wait for OceanBase to be ready (boot success)
@@ -235,6 +268,36 @@ jobs:
             exit 1
           fi
 
+      - name: Wait for MySQL to be ready (mysqladmin ping)
+        if: matrix.db-type == 'mysql'
+        run: |
+          set -e
+          echo "Waiting for mysql to be ready..."
+          timeout=300
+          interval=5
+
+          while [ $timeout -gt 0 ]; do
+            if ! docker ps | grep -q "langchain_mysql_test"; then
+              echo "MySQL container stopped unexpectedly."
+              docker logs "langchain_mysql_test" || true
+              exit 1
+            fi
+
+            if docker exec "langchain_mysql_test" mysqladmin ping -h 127.0.0.1 -uroot -prootpass --silent; then
+              echo "MySQL is ready."
+              break
+            fi
+
+            sleep $interval
+            timeout=$((timeout - interval))
+          done
+
+          if [ $timeout -le 0 ]; then
+            echo "MySQL did not become ready in time."
+            docker logs "langchain_mysql_test" || true
+            exit 1
+          fi
+
       - name: Report LangGraph dependency versions
         run: |
           set -e
@@ -249,6 +312,7 @@ jobs:
           set -e
           poetry run pytest \
             tests/unit_tests/test_checkpointer_async_api.py \
+            tests/unit_tests/test_checkpointer_mysql_compat.py \
             tests/unit_tests/test_legacy_checkpoint_saver.py \
             tests/unit_tests/test_vectorstore_standard.py \
             -v
@@ -272,7 +336,7 @@ jobs:
           OB_HOST: 127.0.0.1
           OB_PORT: ${{ matrix.port }}
           OB_USER: ${{ matrix.user }}
-          OB_PASSWORD: ""
+          OB_PASSWORD: ${{ matrix.db-type == 'mysql' && 'rootpass' || '' }}
           OB_DB: test
           OB_CI_DB_TYPE: ${{ matrix.db-type }}
         run: |
@@ -299,11 +363,12 @@ jobs:
           PY
 
       - name: Run vectorstore integration tests
+        if: matrix.vectorstore-target != ''
         env:
           OB_HOST: 127.0.0.1
           OB_PORT: ${{ matrix.port }}
           OB_USER: ${{ matrix.user }}
-          OB_PASSWORD: ""
+          OB_PASSWORD: ${{ matrix.db-type == 'mysql' && 'rootpass' || '' }}
           OB_DB: test
           OB_CI_DB_TYPE: ${{ matrix.db-type }}
         run: |

--- a/langchain_oceanbase/checkpointer.py
+++ b/langchain_oceanbase/checkpointer.py
@@ -62,8 +62,8 @@ MIGRATIONS = [
     """CREATE TABLE IF NOT EXISTS checkpoint_blobs (
         thread_id VARCHAR(255) NOT NULL,
         checkpoint_ns VARCHAR(255) NOT NULL DEFAULT '',
-        channel VARCHAR(255) NOT NULL,
-        version VARCHAR(255) NOT NULL,
+        channel VARCHAR(128) NOT NULL,
+        version VARCHAR(128) NOT NULL,
         `type` VARCHAR(255) NOT NULL,
         `blob` LONGBLOB,
         PRIMARY KEY (thread_id, checkpoint_ns, channel, version)
@@ -72,8 +72,8 @@ MIGRATIONS = [
     """CREATE TABLE IF NOT EXISTS checkpoint_writes (
         thread_id VARCHAR(255) NOT NULL,
         checkpoint_ns VARCHAR(255) NOT NULL DEFAULT '',
-        checkpoint_id VARCHAR(255) NOT NULL,
-        task_id VARCHAR(255) NOT NULL,
+        checkpoint_id VARCHAR(128) NOT NULL,
+        task_id VARCHAR(128) NOT NULL,
         idx INT NOT NULL,
         channel VARCHAR(255) NOT NULL,
         `type` VARCHAR(255),

--- a/langchain_oceanbase/checkpointer.py
+++ b/langchain_oceanbase/checkpointer.py
@@ -29,7 +29,7 @@ from langgraph.checkpoint.base import (
 )
 from langgraph.checkpoint.serde.base import SerializerProtocol
 from pyobvector import ObVecClient  # type: ignore[import-untyped]
-from sqlalchemy import text
+from sqlalchemy import inspect, text
 from sqlalchemy.engine import Connection
 from sqlalchemy.exc import ResourceClosedError
 
@@ -82,15 +82,21 @@ MIGRATIONS = [
         PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id, task_id, idx)
     );""",
     # Migration 4: Add indexes for better query performance
-    """CREATE INDEX IF NOT EXISTS idx_checkpoints_thread_id
+    """CREATE INDEX idx_checkpoints_thread_id
        ON checkpoints(thread_id);""",
     # Migration 5: Add index on checkpoint_blobs
-    """CREATE INDEX IF NOT EXISTS idx_checkpoint_blobs_thread_id
+    """CREATE INDEX idx_checkpoint_blobs_thread_id
        ON checkpoint_blobs(thread_id);""",
     # Migration 6: Add index on checkpoint_writes
-    """CREATE INDEX IF NOT EXISTS idx_checkpoint_writes_thread_id
+    """CREATE INDEX idx_checkpoint_writes_thread_id
        ON checkpoint_writes(thread_id);""",
 ]
+
+REQUIRED_INDEX_MIGRATIONS = (
+    ("checkpoints", "idx_checkpoints_thread_id", MIGRATIONS[4]),
+    ("checkpoint_blobs", "idx_checkpoint_blobs_thread_id", MIGRATIONS[5]),
+    ("checkpoint_writes", "idx_checkpoint_writes_thread_id", MIGRATIONS[6]),
+)
 
 # SQL for selecting checkpoints with channel values and pending writes
 SELECT_SQL = """
@@ -333,22 +339,59 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
             for v, migration in enumerate(MIGRATIONS[version + 1 :], start=version + 1):
                 try:
                     conn.execute(text(migration))
-                    conn.execute(
-                        text("INSERT INTO checkpoint_migrations (v) VALUES (:v)"),
-                        {"v": v},
-                    )
-                    conn.commit()
-                except Exception:
-                    # Index might already exist, continue
+                except Exception as exc:
                     conn.rollback()
-                    try:
-                        conn.execute(
-                            text("INSERT INTO checkpoint_migrations (v) VALUES (:v)"),
-                            {"v": v},
-                        )
-                        conn.commit()
-                    except Exception:
-                        conn.rollback()
+                    if v < 4 or not self._is_duplicate_index_error(exc):
+                        raise
+                self._record_migration(conn, v)
+                conn.commit()
+
+            # Repair missing indexes for MySQL users who recorded old migrations
+            # before index creation succeeded.
+            self._ensure_required_indexes(conn)
+            conn.commit()
+
+    @staticmethod
+    def _is_duplicate_index_error(exc: Exception) -> bool:
+        """Return True when an index DDL failed because the index already exists."""
+        message = str(exc).lower()
+        duplicate_markers = (
+            "duplicate key name",
+            "already exists",
+            "already exist",
+        )
+        return any(marker in message for marker in duplicate_markers)
+
+    @staticmethod
+    def _record_migration(conn: Connection, version: int) -> None:
+        """Record a successfully applied migration version."""
+        conn.execute(
+            text("INSERT INTO checkpoint_migrations (v) VALUES (:v)"),
+            {"v": version},
+        )
+
+    def _existing_index_names(self, conn: Connection, table_name: str) -> set[str]:
+        """Return the current index names for a table."""
+        try:
+            return {
+                index["name"]
+                for index in inspect(conn).get_indexes(table_name)
+                if index.get("name")
+            }
+        except Exception:
+            result = conn.execute(text(f"SHOW INDEX FROM `{table_name}`"))
+            return {row[2] for row in self._result_fetchall(result)}
+
+    def _ensure_required_indexes(self, conn: Connection) -> None:
+        """Create any missing checkpoint indexes idempotently."""
+        for table_name, index_name, migration_sql in REQUIRED_INDEX_MIGRATIONS:
+            if index_name in self._existing_index_names(conn, table_name):
+                continue
+            try:
+                conn.execute(text(migration_sql))
+            except Exception as exc:
+                if not self._is_duplicate_index_error(exc):
+                    raise
 
     async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
         """Async wrapper for get_tuple."""
@@ -740,12 +783,16 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
                 params["checkpoint_id"] = checkpoint_id
 
         if filter:
-            # OceanBase JSON query syntax
             for key, value in filter.items():
                 param_name = f"filter_{key}"
-                conditions.append(
-                    f"JSON_EXTRACT(c.metadata, '$.{key}') = :{param_name}"
-                )
+                if isinstance(value, str):
+                    conditions.append(
+                        f"JSON_UNQUOTE(JSON_EXTRACT(c.metadata, '$.{key}')) = :{param_name}"
+                    )
+                else:
+                    conditions.append(
+                        f"JSON_EXTRACT(c.metadata, '$.{key}') = :{param_name}"
+                    )
                 params[param_name] = (
                     json.dumps(value)
                     if not isinstance(value, (str, int, float, bool))

--- a/tests/integration_tests/test_checkpoint_conformance.py
+++ b/tests/integration_tests/test_checkpoint_conformance.py
@@ -43,8 +43,13 @@ def _ci_seekdb_server_available() -> bool:
     return _ci_db_type() == "seekdb"
 
 
-def _oceanbase_connection_args_from_env() -> dict[str, str]:
-    """Build OceanBase server connection arguments from the shared CI contract."""
+def _ci_mysql_server_available() -> bool:
+    """Return True when CI provisioned a live MySQL server for tests."""
+    return _ci_db_type() == "mysql"
+
+
+def _server_connection_args_from_env() -> dict[str, str]:
+    """Build server connection arguments from the shared CI contract."""
     return {
         "host": os.getenv("OB_HOST", "127.0.0.1"),
         "port": os.getenv("OB_PORT", "2881"),
@@ -56,7 +61,9 @@ def _oceanbase_connection_args_from_env() -> dict[str, str]:
 
 @checkpointer_test(name="OceanBaseCheckpointSaver")
 async def oceanbase_checkpointer():
-    root = Path(tempfile.mkdtemp(prefix=f"ob_checkpoint_conformance_{uuid.uuid4().hex}_"))
+    root = Path(
+        tempfile.mkdtemp(prefix=f"ob_checkpoint_conformance_{uuid.uuid4().hex}_")
+    )
     db_path = str(root / "seekdb_data")
     saver = OceanBaseCheckpointSaver(connection_args={"db_name": "test"}, path=db_path)
     saver.setup()
@@ -69,10 +76,12 @@ async def oceanbase_checkpointer():
 @checkpointer_test(name="OceanBaseCheckpointSaver-Server")
 async def oceanbase_server_checkpointer():
     if not _ci_oceanbase_server_available():
-        pytest.skip("OceanBase server conformance runs only in the oceanbase CI matrix.")
+        pytest.skip(
+            "OceanBase server conformance runs only in the oceanbase CI matrix."
+        )
 
     saver = OceanBaseCheckpointSaver(
-        connection_args=_oceanbase_connection_args_from_env(),
+        connection_args=_server_connection_args_from_env(),
     )
     saver.setup()
     yield saver
@@ -84,7 +93,19 @@ async def seekdb_server_checkpointer():
         pytest.skip("SeekDB server conformance runs only in the seekdb CI matrix.")
 
     saver = OceanBaseCheckpointSaver(
-        connection_args=_oceanbase_connection_args_from_env(),
+        connection_args=_server_connection_args_from_env(),
+    )
+    saver.setup()
+    yield saver
+
+
+@checkpointer_test(name="OceanBaseCheckpointSaver-MySQL-Server")
+async def mysql_server_checkpointer():
+    if not _ci_mysql_server_available():
+        pytest.skip("MySQL server conformance runs only in the mysql CI matrix.")
+
+    saver = OceanBaseCheckpointSaver(
+        connection_args=_server_connection_args_from_env(),
     )
     saver.setup()
     yield saver
@@ -121,7 +142,9 @@ async def test_checkpoint_conformance_base() -> None:
 async def test_checkpoint_conformance_oceanbase_server() -> None:
     """OceanBaseCheckpointSaver should satisfy the base suite against a real server."""
     if not _ci_oceanbase_server_available():
-        pytest.skip("OceanBase server conformance runs only in the oceanbase CI matrix.")
+        pytest.skip(
+            "OceanBase server conformance runs only in the oceanbase CI matrix."
+        )
 
     report = await validate(
         oceanbase_server_checkpointer,
@@ -148,6 +171,29 @@ async def test_checkpoint_conformance_seekdb_server() -> None:
 
     report = await validate(
         seekdb_server_checkpointer,
+        capabilities={
+            "put",
+            "put_writes",
+            "get_tuple",
+            "list",
+            "delete_thread",
+            "prune",
+        },
+        progress=ProgressCallbacks.verbose(),
+    )
+    report.print_report()
+    assert report.passed_all_base()
+    assert report.results["prune"].passed is True
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_conformance_mysql_server() -> None:
+    """OceanBaseCheckpointSaver should satisfy the base suite against MySQL."""
+    if not _ci_mysql_server_available():
+        pytest.skip("MySQL server conformance runs only in the mysql CI matrix.")
+
+    report = await validate(
+        mysql_server_checkpointer,
         capabilities={
             "put",
             "put_writes",

--- a/tests/integration_tests/test_checkpointer.py
+++ b/tests/integration_tests/test_checkpointer.py
@@ -7,6 +7,7 @@ the BaseCheckpointSaver interface for LangGraph persistence.
 They run against embedded SeekDB when the native runtime is available.
 """
 
+import os
 import shutil
 import uuid
 from pathlib import Path
@@ -37,23 +38,52 @@ def _embedded_seekdb_runtime_available() -> bool:
     return True
 
 
-pytestmark = pytest.mark.skipif(
-    not _embedded_seekdb_runtime_available(),
-    reason=(
-        "embedded SeekDB requires pylibseekdb (e.g. pip install 'pyseekdb>=1.2' "
-        "or pip install 'pyobvector[pyseekdb]')"
-    ),
-)
+def _ci_db_type() -> str:
+    """Return the live database type provisioned by the CI matrix."""
+    return os.getenv("OB_CI_DB_TYPE", "").strip().lower()
 
 
-def create_checkpointer(path: str) -> OceanBaseCheckpointSaver:
-    """Create a checkpointer backed by an embedded SeekDB path."""
-    return OceanBaseCheckpointSaver(connection_args={"db_name": "test"}, path=path)
+def _ci_mysql_server_available() -> bool:
+    """Return True when CI provisioned a live MySQL server for tests."""
+    return _ci_db_type() == "mysql"
+
+
+def _mysql_connection_args_from_env() -> dict[str, str]:
+    """Build MySQL server connection arguments from the shared CI contract."""
+    return {
+        "host": os.getenv("OB_HOST", "127.0.0.1"),
+        "port": os.getenv("OB_PORT", "3306"),
+        "user": os.getenv("OB_USER", "root"),
+        "password": os.getenv("OB_PASSWORD", ""),
+        "db_name": os.getenv("OB_DB", "test"),
+    }
+
+
+def create_checkpointer(
+    *,
+    path: str | None = None,
+    connection_args: dict[str, str] | None = None,
+) -> OceanBaseCheckpointSaver:
+    """Create a checkpointer backed by the selected test backend."""
+    kwargs = {}
+    if path is not None:
+        kwargs["path"] = path
+    return OceanBaseCheckpointSaver(
+        connection_args=connection_args or {"db_name": "test"},
+        **kwargs,
+    )
 
 
 @pytest.fixture
 def seekdb_path(tmp_path: Path) -> str:
     """Create an isolated embedded SeekDB path for a test."""
+    if _ci_mysql_server_available():
+        pytest.skip("Embedded SeekDB path fixture is not used in the mysql CI matrix.")
+    if not _embedded_seekdb_runtime_available():
+        pytest.skip(
+            "embedded SeekDB requires pylibseekdb (e.g. pip install 'pyseekdb>=1.2' "
+            "or pip install 'pyobvector[pyseekdb]')"
+        )
     root = tmp_path / f"checkpoint_seekdb_{uuid.uuid4().hex}"
     root.mkdir(parents=True)
     try:
@@ -63,9 +93,20 @@ def seekdb_path(tmp_path: Path) -> str:
 
 
 @pytest.fixture
-def checkpointer(seekdb_path: str):
+def checkpointer_factory(seekdb_path: str):
+    """Create a new saver instance against the configured backend."""
+    if _ci_mysql_server_available():
+        return lambda: create_checkpointer(
+            connection_args=_mysql_connection_args_from_env()
+        )
+
+    return lambda: create_checkpointer(path=seekdb_path)
+
+
+@pytest.fixture
+def checkpointer(checkpointer_factory):
     """Create a checkpointer for testing."""
-    saver = create_checkpointer(seekdb_path)
+    saver = checkpointer_factory()
     saver.setup()
     return saver
 
@@ -84,9 +125,9 @@ def unique_thread_id():
 class TestOceanBaseCheckpointSaverSetup:
     """Tests for checkpointer setup and initialization."""
 
-    def test_setup_creates_tables(self, seekdb_path: str):
+    def test_setup_creates_tables(self, checkpointer_factory):
         """Test that setup() creates required tables."""
-        saver = create_checkpointer(seekdb_path)
+        saver = checkpointer_factory()
 
         # Setup should not raise
         saver.setup()
@@ -448,10 +489,10 @@ class TestLangGraphIntegration:
         # Cleanup
         checkpointer.delete_thread(unique_thread_id)
 
-    def test_state_recovery_after_restart(self, unique_thread_id, seekdb_path: str):
+    def test_state_recovery_after_restart(self, unique_thread_id, checkpointer_factory):
         """Test that state can be recovered after creating a new checkpointer."""
         # First session
-        checkpointer1 = create_checkpointer(seekdb_path)
+        checkpointer1 = checkpointer_factory()
         checkpointer1.setup()
 
         builder = StateGraph(ConversationState)
@@ -468,7 +509,7 @@ class TestLangGraphIntegration:
         )
 
         # Second session (simulating restart)
-        checkpointer2 = create_checkpointer(seekdb_path)
+        checkpointer2 = checkpointer_factory()
         checkpointer2.setup()
 
         graph2 = builder.compile(checkpointer=checkpointer2)

--- a/tests/integration_tests/test_checkpointer.py
+++ b/tests/integration_tests/test_checkpointer.py
@@ -93,13 +93,14 @@ def seekdb_path(tmp_path: Path) -> str:
 
 
 @pytest.fixture
-def checkpointer_factory(seekdb_path: str):
+def checkpointer_factory(request: pytest.FixtureRequest):
     """Create a new saver instance against the configured backend."""
     if _ci_mysql_server_available():
         return lambda: create_checkpointer(
             connection_args=_mysql_connection_args_from_env()
         )
 
+    seekdb_path = request.getfixturevalue("seekdb_path")
     return lambda: create_checkpointer(path=seekdb_path)
 
 

--- a/tests/integration_tests/test_checkpointer_mysql.py
+++ b/tests/integration_tests/test_checkpointer_mysql.py
@@ -1,0 +1,116 @@
+# mypy: disable-error-code="import-untyped,typeddict-unknown-key,arg-type,no-untyped-def,misc"
+"""Integration tests for OceanBaseCheckpointSaver against a real MySQL server."""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from langgraph.checkpoint.base import Checkpoint, CheckpointMetadata
+from sqlalchemy import text
+
+from langchain_oceanbase import OceanBaseCheckpointSaver
+
+
+def _ci_db_type() -> str:
+    """Return the live database type provisioned by the CI matrix."""
+    return os.getenv("OB_CI_DB_TYPE", "").strip().lower()
+
+
+def _ci_mysql_server_available() -> bool:
+    """Return True when CI provisioned a live MySQL server for tests."""
+    return _ci_db_type() == "mysql"
+
+
+def _mysql_connection_args_from_env() -> dict[str, str]:
+    """Build MySQL server connection arguments from the shared CI contract."""
+    return {
+        "host": os.getenv("OB_HOST", "127.0.0.1"),
+        "port": os.getenv("OB_PORT", "3306"),
+        "user": os.getenv("OB_USER", "root"),
+        "password": os.getenv("OB_PASSWORD", ""),
+        "db_name": os.getenv("OB_DB", "test"),
+    }
+
+
+pytestmark = pytest.mark.skipif(
+    not _ci_mysql_server_available(),
+    reason="MySQL checkpoint tests run only in the mysql CI matrix.",
+)
+
+
+@pytest.fixture
+def checkpointer() -> OceanBaseCheckpointSaver:
+    """Create a MySQL-backed checkpointer for testing."""
+    saver = OceanBaseCheckpointSaver(
+        connection_args=_mysql_connection_args_from_env(),
+    )
+    saver.setup()
+    return saver
+
+
+def _checkpoint(checkpoint_id: str) -> Checkpoint:
+    return {
+        "v": 1,
+        "id": checkpoint_id,
+        "ts": "2024-01-01T00:00:00+00:00",
+        "channel_values": {"messages": ["hello"]},
+        "channel_versions": {"messages": "1"},
+        "versions_seen": {},
+        "pending_sends": [],
+        "updated_channels": None,
+    }
+
+
+def test_setup_creates_required_indexes_against_mysql() -> None:
+    """setup() should create the expected checkpoint indexes on MySQL."""
+    saver = OceanBaseCheckpointSaver(
+        connection_args=_mysql_connection_args_from_env(),
+    )
+    saver.setup()
+    saver.setup()
+
+    expected_indexes = {
+        "checkpoints": "idx_checkpoints_thread_id",
+        "checkpoint_blobs": "idx_checkpoint_blobs_thread_id",
+        "checkpoint_writes": "idx_checkpoint_writes_thread_id",
+    }
+
+    with saver._cursor() as conn:
+        for table_name, index_name in expected_indexes.items():
+            result = conn.execute(text(f"SHOW INDEX FROM `{table_name}`"))
+            actual_indexes = {row[2] for row in result.fetchall()}
+            assert index_name in actual_indexes
+
+
+def test_list_filters_string_metadata_against_mysql(
+    checkpointer: OceanBaseCheckpointSaver,
+) -> None:
+    """String metadata filters should match rows on MySQL JSON columns."""
+    thread_id = f"mysql-thread-{uuid.uuid4()}"
+    config = {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}}
+    checkpoint_id = str(uuid.uuid4())
+    metadata: CheckpointMetadata = {"source": "loop", "step": 1}
+
+    try:
+        stored = checkpointer.put(
+            config,
+            _checkpoint(checkpoint_id),
+            metadata,
+            {"messages": "1"},
+        )
+
+        results = list(
+            checkpointer.list(
+                {"configurable": {"thread_id": thread_id, "checkpoint_ns": ""}},
+                filter={"source": "loop"},
+            )
+        )
+
+        assert [item.checkpoint["id"] for item in results] == [
+            stored["configurable"]["checkpoint_id"]
+        ]
+        assert results[0].metadata["source"] == "loop"
+    finally:
+        checkpointer.delete_thread(thread_id)

--- a/tests/unit_tests/test_checkpointer_mysql_compat.py
+++ b/tests/unit_tests/test_checkpointer_mysql_compat.py
@@ -1,0 +1,117 @@
+"""Unit tests for MySQL-compatible checkpoint saver behavior."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+
+from langchain_oceanbase.checkpointer import MIGRATIONS, OceanBaseCheckpointSaver
+
+
+@pytest.fixture
+def saver(monkeypatch: pytest.MonkeyPatch) -> OceanBaseCheckpointSaver:
+    """Create a saver without opening a real database connection."""
+    monkeypatch.setattr(
+        OceanBaseCheckpointSaver, "_create_client", lambda self, **_: None
+    )
+    return OceanBaseCheckpointSaver(connection_args={})
+
+
+def test_build_where_clause_unquotes_string_metadata_filters(
+    saver: OceanBaseCheckpointSaver,
+) -> None:
+    """String metadata filters should compare against unquoted JSON values."""
+    where_clause, params = saver._build_where_clause(
+        None,
+        {"source": "loop"},
+        None,
+    )
+
+    assert (
+        "JSON_UNQUOTE(JSON_EXTRACT(c.metadata, '$.source')) = :filter_source"
+        in where_clause
+    )
+    assert params == {"filter_source": "loop"}
+
+
+def test_index_migrations_avoid_mysql_unsupported_if_not_exists() -> None:
+    """MySQL should receive CREATE INDEX statements without IF NOT EXISTS."""
+    index_migrations = [
+        migration.strip()
+        for migration in MIGRATIONS
+        if migration.strip().startswith("CREATE INDEX")
+    ]
+
+    assert index_migrations
+    assert all("IF NOT EXISTS" not in migration for migration in index_migrations)
+
+
+class _FakeResult:
+    def __init__(self, row: tuple[int] | None = None) -> None:
+        self._row = row
+
+    def fetchone(self) -> tuple[int] | None:
+        return self._row
+
+
+class _FakeConnection:
+    def __init__(self, *, version: int, fail_sql: str | None = None) -> None:
+        self.version = version
+        self.fail_sql = fail_sql
+        self.executed_sql: list[str] = []
+        self.commits = 0
+        self.rollbacks = 0
+
+    def execute(self, statement, params=None):  # type: ignore[no-untyped-def]
+        sql = str(statement)
+        self.executed_sql.append(sql)
+        if "SELECT COALESCE(MAX(v), -1) FROM checkpoint_migrations" in sql:
+            return _FakeResult((self.version,))
+        if self.fail_sql is not None and self.fail_sql in sql:
+            raise RuntimeError("syntax error")
+        return _FakeResult()
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+def test_setup_repairs_missing_indexes_when_versions_are_already_recorded(
+    saver: OceanBaseCheckpointSaver,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """setup() should repair missing indexes even when index migrations are marked applied."""
+    conn = _FakeConnection(version=6)
+
+    @contextmanager
+    def fake_cursor():  # type: ignore[no-untyped-def]
+        yield conn
+
+    monkeypatch.setattr(saver, "_cursor", fake_cursor)
+    monkeypatch.setattr(saver, "_existing_index_names", lambda *_: set())
+
+    saver.setup()
+
+    create_index_sql = [sql for sql in conn.executed_sql if "CREATE INDEX" in sql]
+    assert len(create_index_sql) == 3
+
+
+def test_setup_reraises_unexpected_missing_index_repair_error(
+    saver: OceanBaseCheckpointSaver,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unexpected index repair failures should abort setup instead of being recorded as success."""
+    conn = _FakeConnection(version=6, fail_sql="CREATE INDEX idx_checkpoints_thread_id")
+
+    @contextmanager
+    def fake_cursor():  # type: ignore[no-untyped-def]
+        yield conn
+
+    monkeypatch.setattr(saver, "_cursor", fake_cursor)
+    monkeypatch.setattr(saver, "_existing_index_names", lambda *_: set())
+
+    with pytest.raises(RuntimeError, match="syntax error"):
+        saver.setup()

--- a/tests/unit_tests/test_checkpointer_mysql_compat.py
+++ b/tests/unit_tests/test_checkpointer_mysql_compat.py
@@ -47,6 +47,17 @@ def test_index_migrations_avoid_mysql_unsupported_if_not_exists() -> None:
     assert all("IF NOT EXISTS" not in migration for migration in index_migrations)
 
 
+def test_mysql_primary_keys_fit_innodb_utf8mb4_index_limit() -> None:
+    """Composite primary key column widths should stay within MySQL's key limit."""
+    checkpoint_blobs = MIGRATIONS[2]
+    checkpoint_writes = MIGRATIONS[3]
+
+    assert "channel VARCHAR(128)" in checkpoint_blobs
+    assert "version VARCHAR(128)" in checkpoint_blobs
+    assert "checkpoint_id VARCHAR(128)" in checkpoint_writes
+    assert "task_id VARCHAR(128)" in checkpoint_writes
+
+
 class _FakeResult:
     def __init__(self, row: tuple[int] | None = None) -> None:
         self._row = row


### PR DESCRIPTION
## What
- add MySQL-focused checkpoint saver compatibility coverage and CI lanes
- tighten checkpoint setup so unexpected index DDL failures are no longer silently marked as migrated
- add post-migration index repair so older MySQL installs with advanced migration rows still recover missing checkpoint indexes
- reuse the shared checkpoint integration suite for MySQL, alongside MySQL-specific schema and JSON metadata assertions
- extend the official LangGraph checkpoint conformance suite to run against a real MySQL server

## Verification
- `./.venv/bin/python -m pytest tests/unit_tests/test_checkpointer_mysql_compat.py tests/unit_tests/test_checkpointer_async_api.py tests/unit_tests/test_legacy_checkpoint_saver.py tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpointer_mysql.py tests/integration_tests/test_checkpoint_conformance.py -q`
- `./.venv/bin/python -m ruff check langchain_oceanbase/checkpointer.py tests/unit_tests/test_checkpointer_mysql_compat.py tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpointer_mysql.py tests/integration_tests/test_checkpoint_conformance.py`
- `./.venv/bin/python - <<'PY' ... yaml.safe_load(Path('.github/workflows/ci.yml').open()) ... PY`

## Notes
- local Docker is not available in this shell, so the real MySQL proof point is the new GitHub CI matrix lanes.
