### PR TITLE
Release 0.5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           - name: embedded-seekdb
             artifact-suffix: embedded-seekdb-base
             db-type: embedded-seekdb
+            poetry-extra-args: -E pyseekdb
             port: ""
             user: ""
             image: ""
@@ -79,6 +80,7 @@ jobs:
           - name: oceanbase
             artifact-suffix: oceanbase-base
             db-type: oceanbase
+            poetry-extra-args: ""
             port: 2881
             user: root@test
             image: oceanbase/oceanbase-ce:4.3.5-lts
@@ -94,6 +96,7 @@ jobs:
           - name: seekdb
             artifact-suffix: seekdb-base
             db-type: seekdb
+            poetry-extra-args: ""
             port: 2882
             user: root
             image: oceanbase/seekdb
@@ -109,6 +112,7 @@ jobs:
           - name: mysql
             artifact-suffix: mysql-base
             db-type: mysql
+            poetry-extra-args: ""
             port: 3306
             user: root
             image: mysql:8.4
@@ -124,6 +128,7 @@ jobs:
           - name: embedded-seekdb, latest-checkpoint-stack
             artifact-suffix: embedded-seekdb-latest
             db-type: embedded-seekdb
+            poetry-extra-args: -E pyseekdb
             port: ""
             user: ""
             image: ""
@@ -139,6 +144,7 @@ jobs:
           - name: oceanbase, latest-checkpoint-stack
             artifact-suffix: oceanbase-latest
             db-type: oceanbase
+            poetry-extra-args: ""
             port: 2881
             user: root@test
             image: oceanbase/oceanbase-ce:4.3.5-lts
@@ -154,6 +160,7 @@ jobs:
           - name: seekdb, latest-checkpoint-stack
             artifact-suffix: seekdb-latest
             db-type: seekdb
+            poetry-extra-args: ""
             port: 2882
             user: root
             image: oceanbase/seekdb
@@ -169,6 +176,7 @@ jobs:
           - name: mysql, latest-checkpoint-stack
             artifact-suffix: mysql-latest
             db-type: mysql
+            poetry-extra-args: ""
             port: 3306
             user: root
             image: mysql:8.4
@@ -206,7 +214,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          poetry install --with test,test_integration --no-interaction
+          poetry install --with test,test_integration --no-interaction ${{ matrix.poetry-extra-args }}
 
       - name: Upgrade to latest supported LangChain and LangGraph stack
         if: matrix.upgrade-latest-stack
@@ -602,7 +610,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          poetry install --with test --no-interaction --no-root
+          poetry install --with test --no-interaction --no-root -E pyseekdb
 
       - name: Test embedding functionality
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
             upgrade-latest-stack: false
             checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpointer_embedded_seekdb.py tests/integration_tests/test_checkpoint_conformance.py
             vectorstore-target: tests/integration_tests/test_vectorstore_standard.py tests/integration_tests/test_embedded_seekdb.py tests/integration_tests/test_vectorstores.py
+            store-target: tests/integration_tests/test_store.py
             chat-history-target: tests/integration_tests/test_chat_message_histories.py
             hybrid-target: tests/integration_tests/test_hybrid_search.py
             ai-functions-target: ""
@@ -86,6 +87,7 @@ jobs:
             upgrade-latest-stack: false
             checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpoint_conformance.py
             vectorstore-target: tests/integration_tests/test_vectorstore_standard.py tests/integration_tests/test_vectorstores.py
+            store-target: tests/integration_tests/test_store.py
             chat-history-target: tests/integration_tests/test_chat_message_histories.py
             hybrid-target: tests/integration_tests/test_hybrid_search.py
             ai-functions-target: ""
@@ -100,6 +102,7 @@ jobs:
             upgrade-latest-stack: false
             checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpoint_conformance.py
             vectorstore-target: tests/integration_tests/test_vectorstore_standard.py tests/integration_tests/test_vectorstores.py
+            store-target: tests/integration_tests/test_store.py
             chat-history-target: tests/integration_tests/test_chat_message_histories.py
             hybrid-target: tests/integration_tests/test_hybrid_search.py
             ai-functions-target: tests/integration_tests/test_ai_functions.py
@@ -114,6 +117,7 @@ jobs:
             upgrade-latest-stack: false
             checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpointer_mysql.py tests/integration_tests/test_checkpoint_conformance.py
             vectorstore-target: ""
+            store-target: tests/integration_tests/test_store.py
             chat-history-target: ""
             hybrid-target: ""
             ai-functions-target: ""
@@ -128,6 +132,7 @@ jobs:
             upgrade-latest-stack: true
             checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpointer_embedded_seekdb.py tests/integration_tests/test_checkpoint_conformance.py
             vectorstore-target: tests/integration_tests/test_vectorstore_standard.py tests/integration_tests/test_embedded_seekdb.py tests/integration_tests/test_vectorstores.py
+            store-target: tests/integration_tests/test_store.py
             chat-history-target: tests/integration_tests/test_chat_message_histories.py
             hybrid-target: tests/integration_tests/test_hybrid_search.py
             ai-functions-target: ""
@@ -142,6 +147,7 @@ jobs:
             upgrade-latest-stack: true
             checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpoint_conformance.py
             vectorstore-target: tests/integration_tests/test_vectorstore_standard.py tests/integration_tests/test_vectorstores.py
+            store-target: tests/integration_tests/test_store.py
             chat-history-target: tests/integration_tests/test_chat_message_histories.py
             hybrid-target: tests/integration_tests/test_hybrid_search.py
             ai-functions-target: ""
@@ -156,6 +162,7 @@ jobs:
             upgrade-latest-stack: true
             checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpoint_conformance.py
             vectorstore-target: tests/integration_tests/test_vectorstore_standard.py tests/integration_tests/test_vectorstores.py
+            store-target: tests/integration_tests/test_store.py
             chat-history-target: tests/integration_tests/test_chat_message_histories.py
             hybrid-target: tests/integration_tests/test_hybrid_search.py
             ai-functions-target: ""
@@ -170,6 +177,7 @@ jobs:
             upgrade-latest-stack: true
             checkpoint-target: tests/integration_tests/test_checkpointer.py tests/integration_tests/test_checkpointer_mysql.py tests/integration_tests/test_checkpoint_conformance.py
             vectorstore-target: ""
+            store-target: tests/integration_tests/test_store.py
             chat-history-target: ""
             hybrid-target: ""
             ai-functions-target: ""
@@ -349,6 +357,7 @@ jobs:
             tests/unit_tests/test_checkpointer_async_api.py \
             tests/unit_tests/test_checkpointer_mysql_compat.py \
             tests/unit_tests/test_legacy_checkpoint_saver.py \
+            tests/unit_tests/test_store.py \
             tests/unit_tests/test_vectorstore_standard.py \
             -v --tb=short --junitxml="$report_path"
 
@@ -401,6 +410,23 @@ jobs:
           echo "Running vectorstore integration tests with ${{ matrix.db-type }}..."
           poetry run pytest ${{ matrix.vectorstore-target }} -v --tb=short --junitxml="$report_path"
 
+      - name: Run store integration tests
+        id: store-tests
+        if: matrix.store-target != ''
+        continue-on-error: true
+        env:
+          OB_HOST: 127.0.0.1
+          OB_PORT: ${{ matrix.port }}
+          OB_USER: ${{ matrix.user }}
+          OB_PASSWORD: ${{ matrix.db-type == 'mysql' && 'rootpass' || '' }}
+          OB_DB: test
+          OB_CI_DB_TYPE: ${{ matrix.db-type }}
+        run: |
+          set -euo pipefail
+          report_path="${RUNNER_TEMP}/store-integration-${{ matrix.artifact-suffix }}.xml"
+          echo "Running store integration tests with ${{ matrix.db-type }}..."
+          poetry run pytest ${{ matrix.store-target }} -v --tb=short --junitxml="$report_path"
+
       - name: Run chat message history integration tests
         id: chat-history-tests
         if: matrix.chat-history-target != ''
@@ -446,6 +472,11 @@ jobs:
           OB_PASSWORD: ${{ matrix.db-type == 'mysql' && 'rootpass' || '' }}
           OB_DB: test
           OB_CI_DB_TYPE: ${{ matrix.db-type }}
+          OB_AI_TEST_URL: ${{ secrets.OB_AI_TEST_URL }}
+          OB_AI_TEST_ACCESS_KEY: ${{ secrets.OB_AI_TEST_ACCESS_KEY }}
+          OB_AI_TEST_EMBED_MODEL: ${{ secrets.OB_AI_TEST_EMBED_MODEL }}
+          OB_AI_TEST_COMPLETE_MODEL: ${{ secrets.OB_AI_TEST_COMPLETE_MODEL }}
+          OB_AI_TEST_PROVIDER: ${{ secrets.OB_AI_TEST_PROVIDER }}
         run: |
           set -euo pipefail
           report_path="${RUNNER_TEMP}/ai-functions-integration-${{ matrix.artifact-suffix }}.xml"
@@ -480,6 +511,7 @@ jobs:
             "${{ steps.comprehensive-tests.outcome }}" \
             "${{ steps.checkpoint-tests.outcome }}" \
             "${{ steps.vectorstore-tests.outcome }}" \
+            "${{ steps.store-tests.outcome }}" \
             "${{ steps.chat-history-tests.outcome }}" \
             "${{ steps.hybrid-tests.outcome }}" \
             "${{ steps.ai-functions-tests.outcome }}"; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,25 +503,68 @@ jobs:
 
       - name: Fail job if any suite failed
         if: always()
+        env:
+          ARTIFACT_SUFFIX: ${{ matrix.artifact-suffix }}
+          VECTORSTORE_TARGET: ${{ matrix.vectorstore-target }}
+          STORE_TARGET: ${{ matrix.store-target }}
+          CHAT_HISTORY_TARGET: ${{ matrix.chat-history-target }}
+          HYBRID_TARGET: ${{ matrix.hybrid-target }}
+          AI_FUNCTIONS_TARGET: ${{ matrix.ai-functions-target }}
+          COMPREHENSIVE_OUTCOME: ${{ steps.comprehensive-tests.outcome }}
         run: |
           set -euo pipefail
-          failed=0
-          for outcome in \
-            "${{ steps.unit-tests.outcome }}" \
-            "${{ steps.comprehensive-tests.outcome }}" \
-            "${{ steps.checkpoint-tests.outcome }}" \
-            "${{ steps.vectorstore-tests.outcome }}" \
-            "${{ steps.store-tests.outcome }}" \
-            "${{ steps.chat-history-tests.outcome }}" \
-            "${{ steps.hybrid-tests.outcome }}" \
-            "${{ steps.ai-functions-tests.outcome }}"; do
-            if [ "$outcome" = "failure" ] || [ "$outcome" = "cancelled" ]; then
-              failed=1
-            fi
-          done
-          if [ "$failed" -ne 0 ]; then
-            exit 1
-          fi
+          python3 - <<'PY'
+          import os
+          import sys
+          import xml.etree.ElementTree as ET
+          from pathlib import Path
+
+          artifact_suffix = os.environ["ARTIFACT_SUFFIX"]
+          report_root = Path(os.environ["RUNNER_TEMP"])
+          expected_reports = [
+              report_root / f"unit-tests-{artifact_suffix}.xml",
+              report_root / f"checkpoint-integration-{artifact_suffix}.xml",
+          ]
+
+          optional_reports = [
+              ("VECTORSTORE_TARGET", f"vectorstore-integration-{artifact_suffix}.xml"),
+              ("STORE_TARGET", f"store-integration-{artifact_suffix}.xml"),
+              ("CHAT_HISTORY_TARGET", f"chat-history-integration-{artifact_suffix}.xml"),
+              ("HYBRID_TARGET", f"hybrid-search-integration-{artifact_suffix}.xml"),
+              ("AI_FUNCTIONS_TARGET", f"ai-functions-integration-{artifact_suffix}.xml"),
+          ]
+          for env_name, filename in optional_reports:
+              if os.environ[env_name]:
+                  expected_reports.append(report_root / filename)
+
+          missing = [str(path) for path in expected_reports if not path.exists()]
+          if missing:
+              print("Missing expected JUnit reports:")
+              for path in missing:
+                  print(f" - {path}")
+              sys.exit(1)
+
+          failures = 0
+          errors = 0
+          for path in expected_reports:
+              root = ET.parse(path).getroot()
+              suites = [root] if root.tag == "testsuite" else root.findall("testsuite")
+              failures += sum(int(suite.attrib.get("failures", 0)) for suite in suites)
+              errors += sum(int(suite.attrib.get("errors", 0)) for suite in suites)
+
+          if failures or errors:
+              print(
+                  f"JUnit suites reported failures={failures} errors={errors}"
+              )
+              sys.exit(1)
+
+          if os.environ["COMPREHENSIVE_OUTCOME"] in {"failure", "cancelled"}:
+              print(
+                  "Comprehensive test step failed with outcome="
+                  f"{os.environ['COMPREHENSIVE_OUTCOME']}"
+              )
+              sys.exit(1)
+          PY
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,5 +1,5 @@
 # This workflow publishes the Python package when a GitHub Release is published.
-# Tag naming is intentionally flexible; prefer plain version tags such as v0.4.0.
+# Tag naming is intentionally flexible; prefer plain version tags such as v0.5.0.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
 
 # This workflow uses actions that are not certified by GitHub.

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,20 +36,9 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Install pyseekdb and dependencies first
-      run: |
-        pip install pyseekdb
-
     - name: Install dependencies
       run: |
-        set +e
-        poetry install --no-interaction --no-cache 2>&1 | tee /tmp/poetry_install.log || true
-        if grep -q "onnxruntime.*abi tags" /tmp/poetry_install.log; then
-          echo "Detected onnxruntime ABI issue, installing dependencies manually..."
-          poetry install --no-interaction --no-cache --no-deps || true
-          poetry run pip install -r <(poetry export --without-hashes --format=requirements.txt 2>/dev/null | grep -v "^onnxruntime" | grep -v "^pyseekdb" || echo "") || true
-        fi
-        set -e
+        poetry install --no-interaction --no-cache --no-root
 
     - name: Build package
       run: |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ OceanBase currently has the ability to store vectors. Users can easily perform t
 ## What's New in 0.5.0
 
 - **LangGraph checkpointing is now a primary workflow**: `OceanBaseCheckpointSaver` is the recommended way to persist graph state, resume threads, and support time-travel in LangGraph applications.
+- **LangGraph store support is now built in**: `OceanBaseStore` provides namespace-scoped memory, JSON filtering, semantic search, async APIs, and TTL-backed expiry for long-term memory workflows.
 - **Storage support is explicit by backend**: OceanBase, SeekDB, embedded SeekDB, and MySQL now have clearer capability boundaries in CI and documentation.
 - **SeekDB coverage is broader**: server-backed SeekDB and embedded SeekDB are both covered for the supported vector and history scenarios.
 
@@ -26,21 +27,23 @@ OceanBase currently has the ability to store vectors. Users can easily perform t
 
 [![LangChain](https://img.shields.io/badge/LangChain-Integration-blue)](https://python.langchain.com/docs/integrations/vectorstores/oceanbase/)
 
-`OceanbaseVectorStore` is the official LangChain integration for OceanBase.
+`OceanbaseVectorStore` is the official LangChain vector store integration for OceanBase.
 
-Support for `ChatMessageHistory` is provided as an additional integration and is not part of the official VectorStore API.
+For LangGraph applications, the recommended persistence surfaces are:
+- `OceanBaseCheckpointSaver` for graph state, replay, and time-travel workflows
+- `OceanBaseStore` for long-term memory, retrieval, and TTL-backed storage
 
 Official documentation:
 https://python.langchain.com/docs/integrations/vectorstores/oceanbase/
 
 ## 0.5.0 Support Matrix
 
-| Backend | LangGraph checkpoint | LangGraph store | Vector store | Chat message history | Hybrid search | Notes |
-| --- | --- | --- | --- | --- | --- | --- |
-| OceanBase | Yes | Yes | Yes | Yes | Yes | Best fit when you want the full SQL + vector database workflow. |
-| SeekDB (server) | Yes | Yes | Yes | Yes | Yes | Full-featured SeekDB deployment, including provider-backed AI function coverage in CI when AI test secrets are configured. |
-| Embedded SeekDB | Yes | Yes | Yes | Yes | Yes | Local path-based runtime through `pyseekdb` / `pylibseekdb`; no server deployment required. |
-| MySQL | Yes | Yes | No | No | No | Checkpoint and LangGraph store workflows are supported without the vector store surface. |
+| Backend | LangGraph checkpoint | LangGraph store | Vector store | Hybrid search | Notes |
+| --- | --- | --- | --- | --- | --- |
+| OceanBase | Yes | Yes | Yes | Yes | Best fit when you want the full SQL + vector database workflow. |
+| SeekDB (server) | Yes | Yes | Yes | Yes | Full-featured SeekDB deployment, including provider-backed AI function coverage in CI when AI test secrets are configured. |
+| Embedded SeekDB | Yes | Yes | Yes | Yes | Local path-based runtime through `pyseekdb` / `pylibseekdb`; no server deployment required. |
+| MySQL | Yes | Yes | No | No | Checkpoint and LangGraph store workflows are supported without the vector store surface. |
 
 ### Recommended by Use Case
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/langchain-oceanbase.svg)](https://badge.fury.io/py/langchain-oceanbase)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
 
-This package contains the LangChain integration with OceanBase. **Current version: 0.4.0**
+This package contains the LangChain integration with OceanBase. **Current version: 0.5.0**
 
 [OceanBase Database](https://github.com/oceanbase/oceanbase) is a distributed relational database.
 It is developed entirely by Ant Group. The OceanBase Database is built on a common server cluster.
@@ -16,7 +16,7 @@ OceanBase currently has the ability to store vectors. Users can easily perform t
 - Perform vector approximate nearest neighbor queries;
 - ...
 
-## What's New in 0.4.0
+## What's New in 0.5.0
 
 - **LangGraph checkpointing is now a primary workflow**: `OceanBaseCheckpointSaver` is the recommended way to persist graph state, resume threads, and support time-travel in LangGraph applications.
 - **Storage support is explicit by backend**: OceanBase, SeekDB, embedded SeekDB, and MySQL now have clearer capability boundaries in CI and documentation.
@@ -33,7 +33,7 @@ Support for `ChatMessageHistory` is provided as an additional integration and is
 Official documentation:
 https://python.langchain.com/docs/integrations/vectorstores/oceanbase/
 
-## 0.4.0 Support Matrix
+## 0.5.0 Support Matrix
 
 | Backend | LangGraph checkpoint | LangGraph store | Vector store | Chat message history | Hybrid search | Notes |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -85,7 +85,7 @@ pip install -U langchain-oceanbase
 - pyobvector >=0.2.0 (required for database client)
 - pyseekdb >=0.1.0 (required dependency; use **>=1.2** on supported platforms for **embedded SeekDB** and the `pylibseekdb` runtime)
 
-> **Tip**: The current version (0.4.0) supports `langchain-core >=1.0.0`. See [CHANGELOG.md](./CHANGELOG.md) for version history.
+> **Tip**: The current version (0.5.0) supports `langchain-core >=1.0.0`. See [CHANGELOG.md](./CHANGELOG.md) for version history.
 
 ### Platform Support
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ pip install -U langchain-oceanbase
 - Python >=3.11
 - langchain-core >=1.0.0
 - pyobvector >=0.2.0 (required for database client)
-- pyseekdb >=0.1.0 (required dependency; use **>=1.2** on supported platforms for **embedded SeekDB** and the `pylibseekdb` runtime)
+- `pyseekdb` extra (optional; install `langchain-oceanbase[pyseekdb]` for built-in embeddings and embedded SeekDB support)
 
 > **Tip**: The current version (0.5.0) supports `langchain-core >=1.0.0`. See [CHANGELOG.md](./CHANGELOG.md) for version history.
 
@@ -97,7 +97,13 @@ pip install -U langchain-oceanbase
 
 ### Built-in Embedding Dependencies
 
-For built-in embedding functionality (no API keys required), `pyseekdb` is automatically installed as an optional dependency. It provides:
+For built-in embedding functionality (no API keys required), install the optional `pyseekdb` extra:
+
+```bash
+pip install -U "langchain-oceanbase[pyseekdb]"
+```
+
+It provides:
 - Local ONNX-based embedding inference
 - Default embedding model: `all-MiniLM-L6-v2` (384 dimensions)
 - No external API calls needed

--- a/README.md
+++ b/README.md
@@ -35,16 +35,17 @@ https://python.langchain.com/docs/integrations/vectorstores/oceanbase/
 
 ## 0.4.0 Support Matrix
 
-| Backend | LangGraph checkpoint | Vector store | Chat message history | Hybrid search | Notes |
-| --- | --- | --- | --- | --- | --- |
-| OceanBase | Yes | Yes | Yes | Yes | Best fit when you want the full SQL + vector database workflow. |
-| SeekDB (server) | Yes | Yes | Yes | Yes | Full-featured SeekDB deployment, including the current AI function test coverage in CI. |
-| Embedded SeekDB | Yes | Yes | Yes | Yes | Local path-based runtime through `pyseekdb` / `pylibseekdb`; no server deployment required. |
-| MySQL | Yes | No | No | No | Checkpoint-focused backend only; vector and search features are out of scope. |
+| Backend | LangGraph checkpoint | LangGraph store | Vector store | Chat message history | Hybrid search | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| OceanBase | Yes | Yes | Yes | Yes | Yes | Best fit when you want the full SQL + vector database workflow. |
+| SeekDB (server) | Yes | Yes | Yes | Yes | Yes | Full-featured SeekDB deployment, including provider-backed AI function coverage in CI when AI test secrets are configured. |
+| Embedded SeekDB | Yes | Yes | Yes | Yes | Yes | Local path-based runtime through `pyseekdb` / `pylibseekdb`; no server deployment required. |
+| MySQL | Yes | Yes | No | No | No | Checkpoint and LangGraph store workflows are supported without the vector store surface. |
 
 ### Recommended by Use Case
 
 - **LangGraph state persistence**: use OceanBase, SeekDB, embedded SeekDB, or MySQL depending on your operational requirements.
+- **LangGraph long-term memory / store API**: use `OceanBaseStore` when you need namespace-scoped key/value memory with filtering, semantic search, and TTL.
 - **Vector store and retrieval workflows**: use OceanBase, SeekDB server, or embedded SeekDB.
 - **Hybrid retrieval with dense + sparse + full-text search**: use OceanBase, SeekDB server, or embedded SeekDB.
 - **Simple checkpoint-only deployments**: MySQL remains supported for checkpoint storage, but not vector features.
@@ -52,6 +53,7 @@ https://python.langchain.com/docs/integrations/vectorstores/oceanbase/
 ## Features
 
 * **LangGraph Checkpointing**: Persist LangGraph conversation checkpoints with `OceanBaseCheckpointSaver`, including resume, replay, and time-travel workflows for multi-thread graph state. See [Migration Guide](./docs/migration_guide.md) and [examples/langgraph_agent.py](./examples/langgraph_agent.py).
+* **LangGraph Store**: Persist long-term memory with `OceanBaseStore`, including namespace-scoped key/value items, JSON filters, semantic search, async methods, and TTL-based expiry.
 * **Vector Storage**: Store embeddings from LangChain models in OceanBase, SeekDB, or embedded SeekDB with automatic table creation and index management.
 * **Built-in Embedding**: Built-in embedding function using `all-MiniLM-L6-v2` model (384 dimensions) with no API keys required. Perfect for quick prototyping and local development.
   * **No API Keys Required**: Uses local ONNX models, no external API calls needed
@@ -130,6 +132,7 @@ Choose your preferred format:
 - **[AI Functions Guide](./docs/ai_functions.md)** - Documentation for AI Functions (AI_EMBED, AI_COMPLETE, AI_RERANK)
 - **[AI Functions Guide (Notebook)](./docs/ai_functions.ipynb)** - Interactive notebook for AI Functions
 - **[Migration Guide](./docs/migration_guide.md)** - Migrating to LangGraph Checkpointer and schema changes
+- **[LangGraph Store example](./examples/langgraph_store.py)** - Runnable example for namespace-scoped memory, semantic search, and TTL
 
 #### Built-in Embedding Sections:
 - [**Installation**](./docs/embeddings.md#installation) - Install required packages
@@ -155,6 +158,46 @@ Choose your preferred format:
 - [**Model Configuration API**](./docs/ai_functions.md#model-configuration-api) - Setup AI models and endpoints
 
 ### Quick Start
+
+#### Using LangGraph Store Memory
+
+```python
+from langchain_core.embeddings import Embeddings
+from langchain_oceanbase import OceanBaseStore
+
+
+class DemoEmbeddings(Embeddings):
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [self.embed_query(text) for text in texts]
+
+    def embed_query(self, text: str) -> list[float]:
+        lowered = text.lower()
+        return [
+            1.0 if "python" in lowered else 0.0,
+            1.0 if "database" in lowered else 0.0,
+            float((len(lowered) % 13) + 1),
+        ]
+
+
+store = OceanBaseStore(
+    connection_args={
+        "host": "127.0.0.1",
+        "port": "2881",
+        "user": "root@test",
+        "password": "",
+        "db_name": "test",
+    },
+    index={"dims": 3, "embed": DemoEmbeddings(), "fields": ["memory"]},
+    ttl_config={"refresh_on_read": True, "default_ttl": 60},
+)
+store.setup()
+
+namespace = ("memories", "user-123")
+store.put(namespace, "favorite-language", {"memory": "The user prefers Python."})
+results = store.search(namespace, query="python", limit=3)
+```
+
+See [examples/langgraph_store.py](./examples/langgraph_store.py) for a complete runnable example.
 
 #### Using Built-in Embedding (No API Keys Required)
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ OceanBase currently has the ability to store vectors. Users can easily perform t
 
 ## What's New in 0.5.0
 
-- **LangGraph checkpointing is now a primary workflow**: `OceanBaseCheckpointSaver` is the recommended way to persist graph state, resume threads, and support time-travel in LangGraph applications.
-- **LangGraph store support is now built in**: `OceanBaseStore` provides namespace-scoped memory, JSON filtering, semantic search, async APIs, and TTL-backed expiry for long-term memory workflows.
-- **Storage support is explicit by backend**: OceanBase, SeekDB, embedded SeekDB, and MySQL now have clearer capability boundaries in CI and documentation.
-- **SeekDB coverage is broader**: server-backed SeekDB and embedded SeekDB are both covered for the supported vector and history scenarios.
+- **The full LangChain persistence pack is now in one release**: `OceanbaseVectorStore`, `OceanBaseCheckpointSaver`, and `OceanBaseStore` are all supported in `0.5.0`.
+- **OceanBase and seekdb are full-surface backends**: both cover vectorstore, checkpoint, and store workflows, with hybrid retrieval support on the vector side.
+- **MySQL remains the compatibility option for on-prem deployments**: if your environment already standardizes on MySQL, you can use it for checkpoint and store workloads without taking on vector infrastructure.
+- **Built-in embeddings and embedded seekdb are now explicitly optional**: install `langchain-oceanbase[pyseekdb]` when you want the bundled embedding runtime or local embedded seekdb.
 
 ## LangChain Integration
 
@@ -33,6 +33,11 @@ For LangGraph applications, the recommended persistence surfaces are:
 - `OceanBaseCheckpointSaver` for graph state, replay, and time-travel workflows
 - `OceanBaseStore` for long-term memory, retrieval, and TTL-backed storage
 
+In `0.5.0`, the package story is straightforward:
+- OceanBase: full pack support for vectorstore + checkpoint + store
+- seekdb: full pack support for vectorstore + checkpoint + store
+- MySQL: compatible checkpoint + store backend for existing on-prem MySQL estates
+
 Official documentation:
 https://python.langchain.com/docs/integrations/vectorstores/oceanbase/
 
@@ -41,31 +46,31 @@ https://python.langchain.com/docs/integrations/vectorstores/oceanbase/
 | Backend | LangGraph checkpoint | LangGraph store | Vector store | Hybrid search | Notes |
 | --- | --- | --- | --- | --- | --- |
 | OceanBase | Yes | Yes | Yes | Yes | Best fit when you want the full SQL + vector database workflow. |
-| SeekDB (server) | Yes | Yes | Yes | Yes | Full-featured SeekDB deployment, including provider-backed AI function coverage in CI when AI test secrets are configured. |
-| Embedded SeekDB | Yes | Yes | Yes | Yes | Local path-based runtime through `pyseekdb` / `pylibseekdb`; no server deployment required. |
-| MySQL | Yes | Yes | No | No | Checkpoint and LangGraph store workflows are supported without the vector store surface. |
+| seekdb (server) | Yes | Yes | Yes | Yes | Full-pack seekdb deployment, including provider-backed AI function coverage in CI when AI test secrets are configured. |
+| embedded seekdb | Yes | Yes | Yes | Yes | Local path-based runtime through `pyseekdb` / `pylibseekdb`; no server deployment required. |
+| MySQL | Yes | Yes | No | No | Use your existing on-prem MySQL deployment for checkpoint and store compatibility when you do not need vector or hybrid retrieval. |
 
 ### Recommended by Use Case
 
-- **LangGraph state persistence**: use OceanBase, SeekDB, embedded SeekDB, or MySQL depending on your operational requirements.
+- **LangGraph state persistence**: use OceanBase, seekdb, embedded seekdb, or MySQL depending on your operational requirements.
 - **LangGraph long-term memory / store API**: use `OceanBaseStore` when you need namespace-scoped key/value memory with filtering, semantic search, and TTL.
-- **Vector store and retrieval workflows**: use OceanBase, SeekDB server, or embedded SeekDB.
-- **Hybrid retrieval with dense + sparse + full-text search**: use OceanBase, SeekDB server, or embedded SeekDB.
-- **Simple checkpoint-only deployments**: MySQL remains supported for checkpoint storage, but not vector features.
+- **Vector store and retrieval workflows**: use OceanBase, seekdb server, or embedded seekdb.
+- **Hybrid retrieval with dense + sparse + full-text search**: use OceanBase, seekdb server, or embedded seekdb.
+- **Existing on-prem MySQL estates**: MySQL remains supported for checkpoint and store workflows, but not vector features.
 
 ## Features
 
-* **LangGraph Checkpointing**: Persist LangGraph conversation checkpoints with `OceanBaseCheckpointSaver`, including resume, replay, and time-travel workflows for multi-thread graph state. See [Migration Guide](./docs/migration_guide.md) and [examples/langgraph_agent.py](./examples/langgraph_agent.py).
-* **LangGraph Store**: Persist long-term memory with `OceanBaseStore`, including namespace-scoped key/value items, JSON filters, semantic search, async methods, and TTL-based expiry.
-* **Vector Storage**: Store embeddings from LangChain models in OceanBase, SeekDB, or embedded SeekDB with automatic table creation and index management.
+* **LangGraph Checkpointing**: Persist LangGraph conversation checkpoints with `OceanBaseCheckpointSaver`, including resume, replay, and time-travel workflows for multi-thread graph state. See [Migration Guide](./docs/migration_guide.md), [checkpoint notebook](./docs/langgraph_checkpoint.ipynb), and [examples/langgraph_agent.py](./examples/langgraph_agent.py).
+* **LangGraph Store**: Persist long-term memory with `OceanBaseStore`, including namespace-scoped key/value items, JSON filters, semantic search, async methods, and TTL-based expiry. See the [store notebook](./docs/langgraph_store.ipynb) and [examples/langgraph_store.py](./examples/langgraph_store.py).
+* **Vector Storage**: Store embeddings from LangChain models in OceanBase, seekdb, or embedded seekdb with automatic table creation and index management.
 * **Built-in Embedding**: Built-in embedding function using `all-MiniLM-L6-v2` model (384 dimensions) with no API keys required. Perfect for quick prototyping and local development.
   * **No API Keys Required**: Uses local ONNX models, no external API calls needed
   * **Quick Start**: Perfect for rapid prototyping and testing
   * **LangChain Compatible**: Fully compatible with LangChain's `Embeddings` interface
   * **Batch Processing**: Supports efficient batch embedding generation
-  * **Automatic Integration**: Can be automatically used in `OceanbaseVectorStore` by setting `embedding_function=None`
+  * **Automatic Integration**: Can be automatically used in `OceanbaseVectorStore` by setting `embedding_function=None` after installing `langchain-oceanbase[pyseekdb]`
   * **Technical Specs**: Model `all-MiniLM-L6-v2`, 384 dimensions, ONNX Runtime inference
-* **Embedded SeekDB (optional)**: Run local embedded [SeekDB](https://github.com/oceanbase/pyseekdb) through pyobvector (`path=` or `pyseekdb_client=` on `OceanbaseVectorStore`) without OceanBase; requires `pyobvector[pyseekdb]` or a recent `pyseekdb` that installs `pylibseekdb`. See [docs/vectorstores.md#embedded-seekdb-optional](./docs/vectorstores.md#embedded-seekdb-optional) and [examples/embedded_seekdb_vectorstore.py](./examples/embedded_seekdb_vectorstore.py).
+* **Embedded seekdb (optional)**: Run local embedded [seekdb](https://github.com/oceanbase/pyseekdb) through pyobvector (`path=` or `pyseekdb_client=` on `OceanbaseVectorStore`) without OceanBase; install `langchain-oceanbase[pyseekdb]` or a recent `pyseekdb` that installs `pylibseekdb`. See [docs/vectorstores.md#embedded-seekdb-optional](./docs/vectorstores.md#embedded-seekdb-optional) and [examples/embedded_seekdb_vectorstore.py](./examples/embedded_seekdb_vectorstore.py).
 * **Similarity Search**: Perform efficient similarity searches on vector data with multiple distance metrics (L2, cosine, inner product).
 * **Hybrid Search**: Combine vector search with sparse vector search and full-text search for improved results with configurable weights.
 * **Maximal Marginal Relevance**: Filter for diversity in search results to avoid redundant information.
@@ -86,7 +91,7 @@ pip install -U langchain-oceanbase
 - Python >=3.11
 - langchain-core >=1.0.0
 - pyobvector >=0.2.0 (required for database client)
-- `pyseekdb` extra (optional; install `langchain-oceanbase[pyseekdb]` for built-in embeddings and embedded SeekDB support)
+- `pyseekdb` extra (optional; install `langchain-oceanbase[pyseekdb]` for built-in embeddings and embedded seekdb support)
 
 > **Tip**: The current version (0.5.0) supports `langchain-core >=1.0.0`. See [CHANGELOG.md](./CHANGELOG.md) for version history.
 
@@ -129,8 +134,8 @@ docker run --name=oceanbase -e MODE=mini -e OB_SERVER_IP=127.0.0.1 -p 2881:2881 
 Choose your preferred format:
 
 - **[Jupyter Notebook](./docs/vectorstores.ipynb)** - Interactive notebook with executable code cells
-- **[Markdown](./docs/vectorstores.md)** - Static documentation for easy reading (includes [embedded SeekDB](./docs/vectorstores.md#embedded-seekdb-optional))
-- **[Embedded SeekDB example](./examples/embedded_seekdb_vectorstore.py)** - Runnable script using local SeekDB without Docker
+- **[Markdown](./docs/vectorstores.md)** - Static documentation for easy reading (includes [embedded seekdb](./docs/vectorstores.md#embedded-seekdb-optional))
+- **[Embedded seekdb example](./examples/embedded_seekdb_vectorstore.py)** - Runnable script using local seekdb without Docker
 
 ### Additional Resources
 
@@ -140,7 +145,9 @@ Choose your preferred format:
 - **[Hybrid Search Guide (Markdown)](./docs/hybrid_search.md)** - Static documentation for hybrid search
 - **[AI Functions Guide](./docs/ai_functions.md)** - Documentation for AI Functions (AI_EMBED, AI_COMPLETE, AI_RERANK)
 - **[AI Functions Guide (Notebook)](./docs/ai_functions.ipynb)** - Interactive notebook for AI Functions
+- **[LangGraph Checkpoint notebook](./docs/langgraph_checkpoint.ipynb)** - Interactive notebook for `OceanBaseCheckpointSaver`
 - **[Migration Guide](./docs/migration_guide.md)** - Migrating to LangGraph Checkpointer and schema changes
+- **[LangGraph Store notebook](./docs/langgraph_store.ipynb)** - Interactive notebook for `OceanBaseStore`
 - **[LangGraph Store example](./examples/langgraph_store.py)** - Runnable example for namespace-scoped memory, semantic search, and TTL
 
 #### Built-in Embedding Sections:
@@ -349,7 +356,7 @@ You can verify this example without OceanBase (imports and constructor only) by 
    docker run --name=oceanbase -e MODE=mini -e OB_SERVER_IP=127.0.0.1 \
        -p 2881:2881 -d oceanbase/oceanbase-ce:4.4.1.0-100000032025101610
    ```
-2. Alternatively, use SeekDB which also supports AI functions
+2. Alternatively, use seekdb which also supports AI functions
 3. Check current version:
    ```sql
    SELECT version();
@@ -433,7 +440,7 @@ cd langchain-oceanbase
 # start OceanBase
 make docker-up
 
-# or start SeekDB (lightweight alternative)
+# or start seekdb (lightweight alternative)
 make docker-up-seek
 ```
 
@@ -462,7 +469,7 @@ python examples/hybrid_search_demo.py
 ## Files of interest
 
 - `docker-compose.yml` — OceanBase CE service for local development
-- `docker-compose.seekdb.yml` — SeekDB lightweight alternative
+- `docker-compose.seekdb.yml` — seekdb lightweight alternative
 - `Makefile` — convenience targets: `make docker-up`, `make docker-down`, `make docker-logs`, plus format/lint/typecheck/test helpers
 - `CONTRIBUTING.md` — developer setup, running tests, code style, PR process
 - `examples/` — `quickstart.py`, `rag_demo.py`, `hybrid_search_demo.py`, and `examples/README.md`
@@ -475,7 +482,7 @@ make test
 # or: poetry run pytest tests/unit_tests/
 ```
 
-- Integration tests (requires OceanBase/SeekDB, e.g. `make docker-up`):
+- Integration tests (requires OceanBase/seekdb, e.g. `make docker-up`):
 ```bash
 make docker-up
 make integration_tests

--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -7,10 +7,10 @@ This guide demonstrates how to use the built-in embedding functionality provided
 
 ## Installation
 
-The built-in embedding functionality requires the `pyseekdb` package, which uses ONNX runtime for local inference:
+The built-in embedding functionality requires the optional `pyseekdb` extra, which uses ONNX runtime for local inference:
 
 ```bash
-pip install -qU "langchain-oceanbase" "pyseekdb"
+pip install -qU "langchain-oceanbase[pyseekdb]"
 ```
 
 ## Method 1: Direct Use of DefaultEmbeddingFunction

--- a/docs/langgraph_checkpoint.ipynb
+++ b/docs/langgraph_checkpoint.ipynb
@@ -1,0 +1,261 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "sidebar_label: LangGraph Checkpoint\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LangGraph Checkpoint with OceanBase\n",
+    "\n",
+    "This notebook shows how to use `OceanBaseCheckpointSaver` as the persistence layer for a LangGraph application.\n",
+    "\n",
+    "It covers:\n",
+    "- creating a simple graph with message state\n",
+    "- setting up the OceanBase checkpoint backend\n",
+    "- resuming a thread by `thread_id`\n",
+    "- listing historical checkpoints for time-travel style inspection\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installation\n",
+    "\n",
+    "Install the package together with LangGraph:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU langchain-oceanbase langgraph"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Start OceanBase\n",
+    "\n",
+    "For a local demo, start OceanBase in Docker:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker run --name=oceanbase -e MODE=mini -e OB_SERVER_IP=127.0.0.1 -p 2881:2881 -d oceanbase/oceanbase-ce:latest"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define the graph state\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Annotated, TypedDict\n",
+    "\n",
+    "from langchain_core.messages import AIMessage, BaseMessage, HumanMessage\n",
+    "from langgraph.graph import END, START, StateGraph\n",
+    "from langgraph.graph.message import add_messages\n",
+    "\n",
+    "\n",
+    "class ConversationState(TypedDict):\n",
+    "    messages: Annotated[list[BaseMessage], add_messages]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build a simple node and graph\n",
+    "\n",
+    "The notebook uses a deterministic echo node so the example is runnable without external LLM credentials.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def chatbot_node(state: ConversationState) -> dict:\n",
+    "    last_message = state[\"messages\"][-1]\n",
+    "    response_content = f\"You said: {last_message.content}\"\n",
+    "\n",
+    "    if \"memory\" in last_message.content.lower():\n",
+    "        history = \"\\n\".join(\n",
+    "            f\"- {msg.__class__.__name__}: {msg.content}\" for msg in state[\"messages\"]\n",
+    "        )\n",
+    "        response_content = f\"Conversation history:\\n{history}\"\n",
+    "\n",
+    "    return {\"messages\": [AIMessage(content=response_content)]}\n",
+    "\n",
+    "\n",
+    "def build_graph():\n",
+    "    builder = StateGraph(ConversationState)\n",
+    "    builder.add_node(\"chatbot\", chatbot_node)\n",
+    "    builder.add_edge(START, \"chatbot\")\n",
+    "    builder.add_edge(\"chatbot\", END)\n",
+    "    return builder"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure `OceanBaseCheckpointSaver`\n",
+    "\n",
+    "Adjust the connection arguments if you are using cloud OceanBase, seekdb, or a different local setup.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from langchain_oceanbase import OceanBaseCheckpointSaver\n",
+    "\n",
+    "\n",
+    "connection_args = {\n",
+    "    \"host\": os.getenv(\"OCEANBASE_HOST\", \"127.0.0.1\"),\n",
+    "    \"port\": os.getenv(\"OCEANBASE_PORT\", \"2881\"),\n",
+    "    \"user\": os.getenv(\"OCEANBASE_USER\", \"root@test\"),\n",
+    "    \"password\": os.getenv(\"OCEANBASE_PASSWORD\", \"\"),\n",
+    "    \"db_name\": os.getenv(\"OCEANBASE_DB\", \"test\"),\n",
+    "}\n",
+    "\n",
+    "checkpointer = OceanBaseCheckpointSaver(connection_args=connection_args)\n",
+    "checkpointer.setup()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compile the graph with checkpoint persistence\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "graph = build_graph().compile(checkpointer=checkpointer)\n",
+    "config = {\"configurable\": {\"thread_id\": \"checkpoint-demo-thread\"}}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run a conversation\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for text in [\n",
+    "    \"Hello from LangGraph.\",\n",
+    "    \"Please remember this thread.\",\n",
+    "    \"Show me the memory.\",\n",
+    "]:\n",
+    "    result = graph.invoke({\"messages\": [HumanMessage(content=text)]}, config)\n",
+    "    print(\"User:\", text)\n",
+    "    print(\"Agent:\", result[\"messages\"][-1].content)\n",
+    "    print(\"-\" * 40)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Resume state by `thread_id`\n",
+    "\n",
+    "This is the core migration path from `ChatMessageHistory`: LangGraph state is stored automatically and organized by thread.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "state_snapshot = graph.get_state(config)\n",
+    "len(state_snapshot.values.get(\"messages\", []))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect checkpoints\n",
+    "\n",
+    "You can iterate through stored checkpoints for debugging, replay, or time-travel workflows.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i, checkpoint in enumerate(checkpointer.list(config, limit=5), start=1):\n",
+    "    checkpoint_id = checkpoint.config[\"configurable\"].get(\"checkpoint_id\")\n",
+    "    step = checkpoint.metadata.get(\"step\", \"N/A\")\n",
+    "    print(f\"{i}. checkpoint_id={checkpoint_id} step={step}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next Steps\n",
+    "\n",
+    "- See [examples/langgraph_agent.py](../examples/langgraph_agent.py) for the full runnable script.\n",
+    "- See [docs/migration_guide.md](./migration_guide.md) for the migration from `OceanBaseChatMessageHistory` to checkpoint-based LangGraph persistence.\n",
+    "- Use `OceanBaseStore` when you also want namespace-scoped long-term memory alongside graph checkpoints.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/langgraph_store.ipynb
+++ b/docs/langgraph_store.ipynb
@@ -1,0 +1,238 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "sidebar_label: LangGraph Store\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LangGraph Store with OceanBase\n",
+    "\n",
+    "This notebook demonstrates `OceanBaseStore` as the LangGraph long-term memory backend.\n",
+    "\n",
+    "It covers:\n",
+    "- creating a store with deterministic demo embeddings\n",
+    "- writing namespace-scoped items\n",
+    "- exact lookup and semantic search\n",
+    "- listing namespaces for multi-tenant memory layouts\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Installation\n",
+    "\n",
+    "Install the package together with LangGraph support:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU langchain-oceanbase langgraph"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Start OceanBase\n",
+    "\n",
+    "For a local demo, start OceanBase in Docker:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!docker run --name=oceanbase -e MODE=mini -e OB_SERVER_IP=127.0.0.1 -p 2881:2881 -d oceanbase/oceanbase-ce:latest"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Define lightweight demo embeddings\n",
+    "\n",
+    "The notebook uses a small deterministic embedding implementation so it works without the optional `pyseekdb` extra.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.embeddings import Embeddings\n",
+    "\n",
+    "\n",
+    "class DemoEmbeddings(Embeddings):\n",
+    "    def embed_documents(self, texts: list[str]) -> list[list[float]]:\n",
+    "        return [self._embed(text) for text in texts]\n",
+    "\n",
+    "    def embed_query(self, text: str) -> list[float]:\n",
+    "        return self._embed(text)\n",
+    "\n",
+    "    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:\n",
+    "        return self.embed_documents(texts)\n",
+    "\n",
+    "    async def aembed_query(self, text: str) -> list[float]:\n",
+    "        return self.embed_query(text)\n",
+    "\n",
+    "    def _embed(self, text: str) -> list[float]:\n",
+    "        lowered = text.lower()\n",
+    "        return [\n",
+    "            1.0 if \"python\" in lowered else 0.0,\n",
+    "            1.0 if \"database\" in lowered else 0.0,\n",
+    "            float((len(lowered) % 13) + 1),\n",
+    "        ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create and initialize the store\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_oceanbase import OceanBaseStore\n",
+    "\n",
+    "\n",
+    "store = OceanBaseStore(\n",
+    "    connection_args={\n",
+    "        \"host\": \"127.0.0.1\",\n",
+    "        \"port\": \"2881\",\n",
+    "        \"user\": \"root@test\",\n",
+    "        \"password\": \"\",\n",
+    "        \"db_name\": \"test\",\n",
+    "    },\n",
+    "    index={\"dims\": 3, \"embed\": DemoEmbeddings(), \"fields\": [\"memory\"]},\n",
+    "    ttl_config={\"refresh_on_read\": True, \"default_ttl\": 60},\n",
+    ")\n",
+    "store.setup()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Write namespace-scoped memory\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "namespace = (\"memories\", \"user-123\")\n",
+    "\n",
+    "store.put(\n",
+    "    namespace,\n",
+    "    \"favorite-language\",\n",
+    "    {\"memory\": \"The user prefers Python for data tooling.\"},\n",
+    ")\n",
+    "store.put(\n",
+    "    namespace,\n",
+    "    \"database-note\",\n",
+    "    {\"memory\": \"OceanBase is the preferred database backend.\"},\n",
+    "    ttl=30,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exact lookup\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exact_item = store.get(namespace, \"favorite-language\")\n",
+    "exact_item"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Semantic search\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "semantic_results = store.search(namespace, query=\"python tooling\", limit=2)\n",
+    "semantic_results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Namespace discovery\n",
+    "\n",
+    "This is useful when you organize memories by user, tenant, or workflow namespace prefixes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "store.list_namespaces(prefix=(\"memories\",))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next Steps\n",
+    "\n",
+    "- See [examples/langgraph_store.py](../examples/langgraph_store.py) for the full runnable script.\n",
+    "- Use `ttl=` and `ttl_config=` when you want expiring long-term memory.\n",
+    "- Pair `OceanBaseStore` with `OceanBaseCheckpointSaver` when you want both graph state persistence and a separate long-term memory surface.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/vectorstores.md
+++ b/docs/vectorstores.md
@@ -57,7 +57,7 @@ Instead of running an OceanBase server, you can use **embedded SeekDB** via [pyo
 **Install** (installs the embedded runtime `pylibseekdb` on supported platforms):
 
 ```text
-pip install -U "langchain-oceanbase" "pyobvector[pyseekdb]"
+pip install -U "langchain-oceanbase[pyseekdb]"
 ```
 
 If imports fail, upgrade `pyseekdb` so the platform wheel for `pylibseekdb` is installed, for example:

--- a/examples/embedded_seekdb_vectorstore.py
+++ b/examples/embedded_seekdb_vectorstore.py
@@ -7,7 +7,7 @@ Standalone example: ``langchain-oceanbase`` with latest ``pyobvector`` and **emb
 
 Install (virtualenv recommended)::
 
-    pip install -U langchain-oceanbase "pyobvector[pyseekdb]"
+    pip install -U "langchain-oceanbase[pyseekdb]"
 
 Embedded mode needs a recent ``pyseekdb`` that installs the ``pylibseekdb`` wheel. If imports fail::
 
@@ -32,7 +32,7 @@ def _require_embedded_runtime() -> None:
     except ImportError:
         print(
             "pylibseekdb (embedded SeekDB runtime) not found. Install with:\n"
-            '  pip install -U langchain-oceanbase "pyobvector[pyseekdb]"\n'
+            '  pip install -U "langchain-oceanbase[pyseekdb]"\n'
             "or:\n"
             '  pip install -U "pyseekdb>=1.2"',
             file=sys.stderr,

--- a/examples/langgraph_store.py
+++ b/examples/langgraph_store.py
@@ -1,0 +1,69 @@
+"""Minimal LangGraph store example for OceanBaseStore."""
+
+from __future__ import annotations
+
+from langchain_core.embeddings import Embeddings
+
+from langchain_oceanbase import OceanBaseStore
+
+
+class DemoEmbeddings(Embeddings):
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [self._embed(text) for text in texts]
+
+    def embed_query(self, text: str) -> list[float]:
+        return self._embed(text)
+
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
+        return self.embed_documents(texts)
+
+    async def aembed_query(self, text: str) -> list[float]:
+        return self.embed_query(text)
+
+    def _embed(self, text: str) -> list[float]:
+        lowered = text.lower()
+        return [
+            1.0 if "python" in lowered else 0.0,
+            1.0 if "database" in lowered else 0.0,
+            float((len(lowered) % 13) + 1),
+        ]
+
+
+def main() -> None:
+    store = OceanBaseStore(
+        connection_args={
+            "host": "127.0.0.1",
+            "port": "2881",
+            "user": "root@test",
+            "password": "",
+            "db_name": "test",
+        },
+        index={"dims": 3, "embed": DemoEmbeddings(), "fields": ["memory"]},
+        ttl_config={"refresh_on_read": True, "default_ttl": 60},
+    )
+    store.setup()
+
+    namespace = ("memories", "user-123")
+    store.put(
+        namespace,
+        "favorite-language",
+        {"memory": "The user prefers Python for data tooling."},
+    )
+    store.put(
+        namespace,
+        "database-note",
+        {"memory": "OceanBase is the preferred database backend."},
+        ttl=30,
+    )
+
+    exact = store.get(namespace, "favorite-language")
+    semantic = store.search(namespace, query="python tooling", limit=2)
+    namespaces = store.list_namespaces(prefix=("memories",))
+
+    print("Exact item:", exact)
+    print("Semantic results:", semantic)
+    print("Namespaces:", namespaces)
+
+
+if __name__ == "__main__":
+    main()

--- a/langchain_oceanbase/__init__.py
+++ b/langchain_oceanbase/__init__.py
@@ -25,6 +25,11 @@ try:
 except ImportError:
     OceanBaseCheckpointSaver = None  # type: ignore
 
+try:
+    from langchain_oceanbase.store import OceanBaseStore
+except ImportError:
+    OceanBaseStore = None  # type: ignore
+
 # Custom exceptions - always available
 from langchain_oceanbase.exceptions import (
     OceanBaseConfigurationError,
@@ -47,6 +52,7 @@ __all__ = [
     "OceanBaseChatMessageHistory",
     "OceanBaseAIFunctions",
     "OceanBaseCheckpointSaver",
+    "OceanBaseStore",
     "DefaultEmbeddingFunction",
     # Exceptions
     "OceanBaseError",

--- a/langchain_oceanbase/chat_message_histories.py
+++ b/langchain_oceanbase/chat_message_histories.py
@@ -10,10 +10,15 @@ from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.messages import BaseMessage
 from pyobvector import ObVecClient
 from sqlalchemy import JSON, Column, String
+from sqlalchemy.exc import ResourceClosedError
 
 from langchain_oceanbase.vectorstores import DEFAULT_OCEANBASE_CONNECTION
 
 DEFAULT_OCEANBASE_CHAT_MESSAGE_TABLE_NAME = "langchain_chat_message"
+
+
+def _is_empty_result_resource_closed_error(error: ResourceClosedError) -> bool:
+    return "does not return rows" in str(error)
 
 
 class OceanBaseChatMessageHistory(BaseChatMessageHistory):
@@ -205,7 +210,12 @@ class OceanBaseChatMessageHistory(BaseChatMessageHistory):
         )
 
         messages: List[BaseMessage] = []
-        rows = res.fetchall()
+        try:
+            rows = res.fetchall()
+        except ResourceClosedError as exc:
+            if _is_empty_result_resource_closed_error(exc):
+                return []
+            raise
 
         # Sort by created_at timestamp to maintain order
         rows.sort(key=lambda x: int(x[3]) if x[3] else 0)

--- a/langchain_oceanbase/embedding_utils.py
+++ b/langchain_oceanbase/embedding_utils.py
@@ -28,21 +28,43 @@ Usage Examples:
     >>> query_embedding = embeddings.embed_query("Hello")
 """
 
-from __future__ import annotations
-
 import logging
+import platform
 from typing import List, Optional
 
 from langchain_core.embeddings import Embeddings
 
-try:
-    from pyseekdb import DefaultEmbeddingFunction
-except ImportError:
-    DefaultEmbeddingFunction = None  # type: ignore
-
 logger = logging.getLogger(__name__)
 
 __all__ = ["DefaultEmbeddingFunction", "DefaultEmbeddingFunctionAdapter"]
+
+DEFAULT_EMBEDDING_INSTALL_COMMAND = 'pip install -U "langchain-oceanbase[pyseekdb]"'
+
+
+try:
+    from pyseekdb import DefaultEmbeddingFunction
+except ImportError as exc:
+    DefaultEmbeddingFunction = None  # type: ignore[assignment]
+    _PYSEEKDB_IMPORT_ERROR = exc
+else:
+    _PYSEEKDB_IMPORT_ERROR = None
+
+
+def _raise_for_missing_pyseekdb() -> None:
+    message = (
+        "pyseekdb is not installed. "
+        "Install the optional embedding dependencies with: "
+        f"{DEFAULT_EMBEDDING_INSTALL_COMMAND}"
+    )
+    system = platform.system()
+    if system != "Linux":
+        message += (
+            f"\n\nNote: pyseekdb currently has the best support on Linux. "
+            f"Your system is {system}. "
+            "Consider using Linux (via Docker, WSL2, or a Linux VM) "
+            "or connecting to a remote OceanBase/SeekDB instance."
+        )
+    raise ImportError(message) from _PYSEEKDB_IMPORT_ERROR
 
 
 class DefaultEmbeddingFunctionAdapter(Embeddings):
@@ -60,7 +82,7 @@ class DefaultEmbeddingFunctionAdapter(Embeddings):
         self,
         model_name: str = "all-MiniLM-L6-v2",
         preferred_providers: Optional[List[str]] = None,
-    ):
+    ) -> None:
         """
         Initialize the adapter.
 
@@ -70,22 +92,7 @@ class DefaultEmbeddingFunctionAdapter(Embeddings):
         """
         super().__init__()
         if DefaultEmbeddingFunction is None:
-            import platform
-
-            system = platform.system()
-            error_msg = (
-                "pyseekdb is not installed or cannot be imported. "
-                "Please install it with: pip install pyseekdb"
-            )
-            if system != "Linux":
-                error_msg += (
-                    f"\n\nNote: pyseekdb currently only supports Linux platforms. "
-                    f"Your system is {system}. "
-                    "Consider using Linux (via Docker, WSL2, or a Linux VM) "
-                    "or connecting to a remote OceanBase/SeekDB instance."
-                )
-            raise ImportError(error_msg)
-
+            _raise_for_missing_pyseekdb()
         self._pyseekdb_embedding_function = DefaultEmbeddingFunction(
             model_name=model_name,
             preferred_providers=preferred_providers,

--- a/langchain_oceanbase/store.py
+++ b/langchain_oceanbase/store.py
@@ -47,11 +47,16 @@ from sqlalchemy import (
     update,
 )
 from sqlalchemy.engine import Connection, Row
+from sqlalchemy.exc import ResourceClosedError
 
 from langchain_oceanbase.exceptions import OceanBaseConnectionError
 from langchain_oceanbase.vectorstores import DEFAULT_OCEANBASE_CONNECTION
 
 _TOKENIZED_FIELDS_KEY = "__tokenized_fields"
+
+
+def _is_empty_result_resource_closed_error(error: ResourceClosedError) -> bool:
+    return "does not return rows" in str(error)
 
 
 class OceanBaseStore(BaseStore):
@@ -409,7 +414,12 @@ class OceanBaseStore(BaseStore):
             .where(self._live_condition())
             .limit(1)
         )
-        return conn.execute(stmt).fetchone()
+        try:
+            return conn.execute(stmt).fetchone()
+        except ResourceClosedError as exc:
+            if _is_empty_result_resource_closed_error(exc):
+                return None
+            raise
 
     def _fetch_candidate_rows(
         self, conn: Connection, namespace_prefix: tuple[str, ...] | None
@@ -425,7 +435,12 @@ class OceanBaseStore(BaseStore):
             self._items_table.c.created_at,
             self._items_table.c.item_id,
         )
-        return list(conn.execute(stmt).fetchall())
+        try:
+            return list(conn.execute(stmt).fetchall())
+        except ResourceClosedError as exc:
+            if _is_empty_result_resource_closed_error(exc):
+                return []
+            raise
 
     def _row_to_item(self, row: Row[Any]) -> Item:
         mapping = row._mapping

--- a/langchain_oceanbase/store.py
+++ b/langchain_oceanbase/store.py
@@ -30,8 +30,22 @@ from langgraph.store.base import (
     tokenize_path,
 )
 from pyobvector import ObVecClient  # type: ignore[import-untyped]
-from sqlalchemy import JSON, DateTime, Float, Index, MetaData, String, Table, Text
-from sqlalchemy import Column, and_, delete, or_, select, update
+from sqlalchemy import (
+    JSON,
+    Column,
+    DateTime,
+    Float,
+    Index,
+    MetaData,
+    String,
+    Table,
+    Text,
+    and_,
+    delete,
+    or_,
+    select,
+    update,
+)
 from sqlalchemy.engine import Connection, Row
 
 from langchain_oceanbase.exceptions import OceanBaseConnectionError
@@ -185,7 +199,9 @@ class OceanBaseStore(BaseStore):
     def _search_items(self, conn: Connection, op: SearchOp) -> list[SearchItem]:
         rows = self._fetch_candidate_rows(conn, op.namespace_prefix)
         filtered = [
-            row for row in rows if self._matches_filter(row._mapping["value_json"], op.filter)
+            row
+            for row in rows
+            if self._matches_filter(row._mapping["value_json"], op.filter)
         ]
 
         if op.query and self.index_config is not None and self.embeddings is not None:
@@ -210,12 +226,12 @@ class OceanBaseStore(BaseStore):
             self._refresh_ttl(conn, touched)
         return results
 
-    async def _asearch_items(
-        self, conn: Connection, op: SearchOp
-    ) -> list[SearchItem]:
+    async def _asearch_items(self, conn: Connection, op: SearchOp) -> list[SearchItem]:
         rows = self._fetch_candidate_rows(conn, op.namespace_prefix)
         filtered = [
-            row for row in rows if self._matches_filter(row._mapping["value_json"], op.filter)
+            row
+            for row in rows
+            if self._matches_filter(row._mapping["value_json"], op.filter)
         ]
 
         if op.query and self.index_config is not None and self.embeddings is not None:
@@ -285,11 +301,12 @@ class OceanBaseStore(BaseStore):
             touched.append(row)
         return results, touched
 
-    def _list_namespaces(self, conn: Connection, op: ListNamespacesOp) -> list[tuple[str, ...]]:
+    def _list_namespaces(
+        self, conn: Connection, op: ListNamespacesOp
+    ) -> list[tuple[str, ...]]:
         rows = self._fetch_candidate_rows(conn, None)
         namespaces = {
-            tuple(cast(list[str], row._mapping["namespace_json"]))
-            for row in rows
+            tuple(cast(list[str], row._mapping["namespace_json"])) for row in rows
         }
         ordered = sorted(
             ns
@@ -447,11 +464,7 @@ class OceanBaseStore(BaseStore):
         value: dict[str, Any],
         index: Literal[False] | list[str] | None,
     ) -> list[dict[str, Any]] | None:
-        if (
-            index is False
-            or self.index_config is None
-            or self.embeddings is None
-        ):
+        if index is False or self.index_config is None or self.embeddings is None:
             return None
 
         extracted = self._extract_texts(value, index)
@@ -474,11 +487,7 @@ class OceanBaseStore(BaseStore):
         value: dict[str, Any],
         index: Literal[False] | list[str] | None,
     ) -> list[dict[str, Any]] | None:
-        if (
-            index is False
-            or self.index_config is None
-            or self.embeddings is None
-        ):
+        if index is False or self.index_config is None or self.embeddings is None:
             return None
 
         extracted = self._extract_texts(value, index)
@@ -503,7 +512,10 @@ class OceanBaseStore(BaseStore):
             return []
 
         if index is None:
-            paths = cast(list[tuple[str, str | list[str]]], self.index_config[_TOKENIZED_FIELDS_KEY])
+            paths = cast(
+                list[tuple[str, str | list[str]]],
+                self.index_config[_TOKENIZED_FIELDS_KEY],
+            )
         else:
             paths = [
                 (path, tokenize_path(path)) if path != "$" else (path, path)
@@ -518,7 +530,9 @@ class OceanBaseStore(BaseStore):
             if len(texts) == 1:
                 extracted.append((path, texts[0]))
             else:
-                extracted.extend((f"{path}.{idx}", text) for idx, text in enumerate(texts))
+                extracted.extend(
+                    (f"{path}.{idx}", text) for idx, text in enumerate(texts)
+                )
         return extracted
 
     def _matches_filter(
@@ -556,11 +570,7 @@ class OceanBaseStore(BaseStore):
         return "".join(f"{len(part)}:{part}|" for part in namespace)
 
     def _escape_like_pattern(self, value: str) -> str:
-        return (
-            value.replace("\\", "\\\\")
-            .replace("%", "\\%")
-            .replace("_", "\\_")
-        )
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
     def _validate_namespace(self, namespace: tuple[str, ...]) -> None:
         if not namespace:
@@ -643,7 +653,9 @@ class OceanBaseStore(BaseStore):
             return float(value) <= float(operand)
         raise ValueError(f"Unsupported operator: {operator}")
 
-    def _normalize_vector(self, vector: list[float] | tuple[float, ...] | Any) -> list[float]:
+    def _normalize_vector(
+        self, vector: list[float] | tuple[float, ...] | Any
+    ) -> list[float]:
         return [float(value) for value in vector]
 
     def _cosine_similarity(

--- a/langchain_oceanbase/store.py
+++ b/langchain_oceanbase/store.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import math
 import threading
@@ -124,8 +123,14 @@ class OceanBaseStore(BaseStore):
             return [self._execute_op(conn, op) for op in operations]
 
     async def abatch(self, ops: Iterable[Op]) -> list[Result]:
+        self.setup()
         operations = list(ops)
-        return await asyncio.to_thread(self.batch, operations)
+        with self.obvector.engine.begin() as conn:
+            self._delete_expired_items(conn)
+            results: list[Result] = []
+            for op in operations:
+                results.append(await self._aexecute_op(conn, op))
+            return results
 
     def _create_client(self, **kwargs: Any) -> None:
         host = self.connection_args.get("host", "localhost")
@@ -287,7 +292,13 @@ class OceanBaseStore(BaseStore):
         scored.sort(key=lambda item: item[0], reverse=True)
         kept = scored[op.offset : op.offset + op.limit]
         if len(kept) < op.limit:
-            kept.extend((None, row) for row in scoreless[: op.limit - len(kept)])
+            scoreless_offset = max(0, op.offset - len(scored))
+            kept.extend(
+                (None, row)
+                for row in scoreless[
+                    scoreless_offset : scoreless_offset + (op.limit - len(kept))
+                ]
+            )
 
         results: list[SearchItem] = []
         touched: list[Row[Any]] = []
@@ -658,14 +669,21 @@ class OceanBaseStore(BaseStore):
             return value == operand
         if operator == "$ne":
             return value != operand
+        if value is None:
+            return False
+        try:
+            numeric_value = float(value)
+            numeric_operand = float(operand)
+        except (TypeError, ValueError):
+            return False
         if operator == "$gt":
-            return float(value) > float(operand)
+            return numeric_value > numeric_operand
         if operator == "$gte":
-            return float(value) >= float(operand)
+            return numeric_value >= numeric_operand
         if operator == "$lt":
-            return float(value) < float(operand)
+            return numeric_value < numeric_operand
         if operator == "$lte":
-            return float(value) <= float(operand)
+            return numeric_value <= numeric_operand
         raise ValueError(f"Unsupported operator: {operator}")
 
     def _normalize_vector(

--- a/langchain_oceanbase/store.py
+++ b/langchain_oceanbase/store.py
@@ -1,0 +1,667 @@
+"""LangGraph store implementation backed by OceanBase-compatible SQL engines."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import math
+import threading
+from collections.abc import Iterable
+from datetime import datetime, timedelta, timezone
+from typing import Any, Literal, cast
+
+from langchain_core.embeddings import Embeddings
+from langgraph.store.base import (
+    BaseStore,
+    GetOp,
+    IndexConfig,
+    InvalidNamespaceError,
+    Item,
+    ListNamespacesOp,
+    MatchCondition,
+    Op,
+    PutOp,
+    Result,
+    SearchItem,
+    SearchOp,
+    TTLConfig,
+    ensure_embeddings,
+    get_text_at_path,
+    tokenize_path,
+)
+from pyobvector import ObVecClient  # type: ignore[import-untyped]
+from sqlalchemy import JSON, DateTime, Float, Index, MetaData, String, Table, Text
+from sqlalchemy import Column, and_, delete, or_, select, update
+from sqlalchemy.engine import Connection, Row
+
+from langchain_oceanbase.exceptions import OceanBaseConnectionError
+from langchain_oceanbase.vectorstores import DEFAULT_OCEANBASE_CONNECTION
+
+_TOKENIZED_FIELDS_KEY = "__tokenized_fields"
+
+
+class OceanBaseStore(BaseStore):
+    """Persistent LangGraph store for OceanBase, SeekDB, and compatible backends."""
+
+    supports_ttl: bool = True
+
+    def __init__(
+        self,
+        connection_args: dict[str, Any] | None = None,
+        *,
+        index: IndexConfig | None = None,
+        ttl_config: TTLConfig | None = None,
+        table_name: str = "langgraph_store_items",
+        **kwargs: Any,
+    ) -> None:
+        self.connection_args = (
+            connection_args
+            if connection_args is not None
+            else DEFAULT_OCEANBASE_CONNECTION.copy()
+        )
+        self.table_name = table_name
+        self.ttl_config = ttl_config
+        self._kwargs = kwargs
+        self._setup_lock = threading.Lock()
+        self._setup_complete = False
+        self._metadata = MetaData()
+        self._items_table = Table(
+            self.table_name,
+            self._metadata,
+            Column("item_id", String(64), primary_key=True),
+            Column("namespace_path", String(512), nullable=False),
+            Column("namespace_json", JSON, nullable=False),
+            Column("item_key", Text, nullable=False),
+            Column("value_json", JSON, nullable=False),
+            Column("index_data", JSON, nullable=True),
+            Column("created_at", DateTime(timezone=True), nullable=False),
+            Column("updated_at", DateTime(timezone=True), nullable=False),
+            Column("expires_at", DateTime(timezone=True), nullable=True),
+            Column("ttl_minutes", Float, nullable=True),
+            Index(f"idx_{self.table_name}_namespace_path", "namespace_path"),
+            Index(f"idx_{self.table_name}_expires_at", "expires_at"),
+        )
+        self.index_config = self._prepare_index_config(index)
+        self.embeddings: Embeddings | None = None
+        if self.index_config is not None:
+            self.embeddings = ensure_embeddings(self.index_config.get("embed"))
+        self._create_client(**kwargs)
+
+    def setup(self) -> None:
+        """Create the backing table and indexes if they do not already exist."""
+        if self._setup_complete:
+            return
+        with self._setup_lock:
+            if self._setup_complete:
+                return
+            self._metadata.create_all(self.obvector.engine, checkfirst=True)
+            self._setup_complete = True
+
+    def batch(self, ops: Iterable[Op]) -> list[Result]:
+        self.setup()
+        operations = list(ops)
+        with self.obvector.engine.begin() as conn:
+            self._delete_expired_items(conn)
+            return [self._execute_op(conn, op) for op in operations]
+
+    async def abatch(self, ops: Iterable[Op]) -> list[Result]:
+        operations = list(ops)
+        return await asyncio.to_thread(self.batch, operations)
+
+    def _create_client(self, **kwargs: Any) -> None:
+        host = self.connection_args.get("host", "localhost")
+        port = self.connection_args.get("port", "2881")
+        user = self.connection_args.get("user", "root@test")
+        password = self.connection_args.get("password", "")
+        db_name = self.connection_args.get("db_name", "test")
+
+        try:
+            self.obvector: ObVecClient = ObVecClient(
+                uri=f"{host}:{port}",
+                user=user,
+                password=password,
+                db_name=db_name,
+                **kwargs,
+            )
+        except Exception as exc:
+            error_msg = str(exc).lower()
+            if (
+                "connect" in error_msg
+                or "refused" in error_msg
+                or "timeout" in error_msg
+            ):
+                raise OceanBaseConnectionError(
+                    f"Failed to connect to OceanBase: {exc}",
+                    host=host,
+                    port=port,
+                ) from exc
+            raise
+
+    def _prepare_index_config(self, index: IndexConfig | None) -> dict[str, Any] | None:
+        if index is None:
+            return None
+
+        prepared = dict(index)
+        prepared[_TOKENIZED_FIELDS_KEY] = [
+            (path, tokenize_path(path)) if path != "$" else (path, path)
+            for path in cast(list[str], prepared.get("fields") or ["$"])
+        ]
+        return prepared
+
+    def _execute_op(self, conn: Connection, op: Op) -> Result:
+        if isinstance(op, GetOp):
+            return self._get_item(conn, op)
+        if isinstance(op, SearchOp):
+            return self._search_items(conn, op)
+        if isinstance(op, ListNamespacesOp):
+            return self._list_namespaces(conn, op)
+        if isinstance(op, PutOp):
+            self._put_item(conn, op)
+            return None
+        raise ValueError(f"Unknown operation type: {type(op)}")
+
+    async def _aexecute_op(self, conn: Connection, op: Op) -> Result:
+        if isinstance(op, GetOp):
+            return self._get_item(conn, op)
+        if isinstance(op, SearchOp):
+            return await self._asearch_items(conn, op)
+        if isinstance(op, ListNamespacesOp):
+            return self._list_namespaces(conn, op)
+        if isinstance(op, PutOp):
+            await self._aput_item(conn, op)
+            return None
+        raise ValueError(f"Unknown operation type: {type(op)}")
+
+    def _get_item(self, conn: Connection, op: GetOp) -> Item | None:
+        row = self._fetch_item_row(conn, op.namespace, op.key)
+        if row is None:
+            return None
+
+        item = self._row_to_item(row)
+        if op.refresh_ttl and row._mapping["ttl_minutes"] is not None:
+            self._refresh_ttl(conn, [row])
+        return item
+
+    def _search_items(self, conn: Connection, op: SearchOp) -> list[SearchItem]:
+        rows = self._fetch_candidate_rows(conn, op.namespace_prefix)
+        filtered = [
+            row for row in rows if self._matches_filter(row._mapping["value_json"], op.filter)
+        ]
+
+        if op.query and self.index_config is not None and self.embeddings is not None:
+            query_embedding = self._normalize_vector(
+                self.embeddings.embed_query(op.query)
+            )
+            results, touched = self._rank_rows(filtered, query_embedding, op)
+        else:
+            touched = filtered[op.offset : op.offset + op.limit]
+            results = [
+                SearchItem(
+                    namespace=tuple(row._mapping["namespace_json"]),
+                    key=str(row._mapping["item_key"]),
+                    value=cast(dict[str, Any], row._mapping["value_json"]),
+                    created_at=row._mapping["created_at"],
+                    updated_at=row._mapping["updated_at"],
+                )
+                for row in touched
+            ]
+
+        if op.refresh_ttl and touched:
+            self._refresh_ttl(conn, touched)
+        return results
+
+    async def _asearch_items(
+        self, conn: Connection, op: SearchOp
+    ) -> list[SearchItem]:
+        rows = self._fetch_candidate_rows(conn, op.namespace_prefix)
+        filtered = [
+            row for row in rows if self._matches_filter(row._mapping["value_json"], op.filter)
+        ]
+
+        if op.query and self.index_config is not None and self.embeddings is not None:
+            query_embedding = self._normalize_vector(
+                await self.embeddings.aembed_query(op.query)
+            )
+            results, touched = self._rank_rows(filtered, query_embedding, op)
+        else:
+            touched = filtered[op.offset : op.offset + op.limit]
+            results = [
+                SearchItem(
+                    namespace=tuple(row._mapping["namespace_json"]),
+                    key=str(row._mapping["item_key"]),
+                    value=cast(dict[str, Any], row._mapping["value_json"]),
+                    created_at=row._mapping["created_at"],
+                    updated_at=row._mapping["updated_at"],
+                )
+                for row in touched
+            ]
+
+        if op.refresh_ttl and touched:
+            self._refresh_ttl(conn, touched)
+        return results
+
+    def _rank_rows(
+        self,
+        rows: list[Row[Any]],
+        query_embedding: list[float],
+        op: SearchOp,
+    ) -> tuple[list[SearchItem], list[Row[Any]]]:
+        scored: list[tuple[float, Row[Any]]] = []
+        scoreless: list[Row[Any]] = []
+
+        for row in rows:
+            index_data = row._mapping["index_data"] or []
+            if index_data:
+                vectors = [
+                    self._normalize_vector(entry["embedding"])
+                    for entry in index_data
+                    if entry.get("embedding") is not None
+                ]
+                if vectors:
+                    best_score = max(self._cosine_similarity(query_embedding, vectors))
+                    scored.append((best_score, row))
+                    continue
+            scoreless.append(row)
+
+        scored.sort(key=lambda item: item[0], reverse=True)
+        kept = scored[op.offset : op.offset + op.limit]
+        if len(kept) < op.limit:
+            kept.extend((None, row) for row in scoreless[: op.limit - len(kept)])
+
+        results: list[SearchItem] = []
+        touched: list[Row[Any]] = []
+        for score, row in kept:
+            mapping = row._mapping
+            results.append(
+                SearchItem(
+                    namespace=tuple(mapping["namespace_json"]),
+                    key=str(mapping["item_key"]),
+                    value=cast(dict[str, Any], mapping["value_json"]),
+                    created_at=mapping["created_at"],
+                    updated_at=mapping["updated_at"],
+                    score=cast(float | None, score),
+                )
+            )
+            touched.append(row)
+        return results, touched
+
+    def _list_namespaces(self, conn: Connection, op: ListNamespacesOp) -> list[tuple[str, ...]]:
+        rows = self._fetch_candidate_rows(conn, None)
+        namespaces = {
+            tuple(cast(list[str], row._mapping["namespace_json"]))
+            for row in rows
+        }
+        ordered = sorted(
+            ns
+            for ns in namespaces
+            if not op.match_conditions
+            or all(self._does_match(condition, ns) for condition in op.match_conditions)
+        )
+        if op.max_depth is not None:
+            ordered = sorted({ns[: op.max_depth] for ns in ordered})
+        return ordered[op.offset : op.offset + op.limit]
+
+    def _put_item(self, conn: Connection, op: PutOp) -> None:
+        self._validate_namespace(op.namespace)
+        item_id = self._item_id(op.namespace, op.key)
+        if op.value is None:
+            conn.execute(
+                delete(self._items_table).where(self._items_table.c.item_id == item_id)
+            )
+            return
+
+        now = self._now()
+        existing = self._fetch_row_by_item_id(conn, item_id)
+        index_data = self._build_index_entries(op.value, op.index)
+        ttl_minutes = op.ttl
+        expires_at = self._compute_expires_at(now, ttl_minutes)
+
+        values = {
+            "item_id": item_id,
+            "namespace_path": self._encode_namespace(op.namespace),
+            "namespace_json": list(op.namespace),
+            "item_key": str(op.key),
+            "value_json": op.value,
+            "index_data": index_data,
+            "created_at": (
+                existing._mapping["created_at"] if existing is not None else now
+            ),
+            "updated_at": now,
+            "expires_at": expires_at,
+            "ttl_minutes": ttl_minutes,
+        }
+
+        if existing is None:
+            conn.execute(self._items_table.insert().values(**values))
+        else:
+            conn.execute(
+                update(self._items_table)
+                .where(self._items_table.c.item_id == item_id)
+                .values(**values)
+            )
+
+    async def _aput_item(self, conn: Connection, op: PutOp) -> None:
+        self._validate_namespace(op.namespace)
+        item_id = self._item_id(op.namespace, op.key)
+        if op.value is None:
+            conn.execute(
+                delete(self._items_table).where(self._items_table.c.item_id == item_id)
+            )
+            return
+
+        now = self._now()
+        existing = self._fetch_row_by_item_id(conn, item_id)
+        index_data = await self._abuild_index_entries(op.value, op.index)
+        ttl_minutes = op.ttl
+        expires_at = self._compute_expires_at(now, ttl_minutes)
+
+        values = {
+            "item_id": item_id,
+            "namespace_path": self._encode_namespace(op.namespace),
+            "namespace_json": list(op.namespace),
+            "item_key": str(op.key),
+            "value_json": op.value,
+            "index_data": index_data,
+            "created_at": (
+                existing._mapping["created_at"] if existing is not None else now
+            ),
+            "updated_at": now,
+            "expires_at": expires_at,
+            "ttl_minutes": ttl_minutes,
+        }
+
+        if existing is None:
+            conn.execute(self._items_table.insert().values(**values))
+        else:
+            conn.execute(
+                update(self._items_table)
+                .where(self._items_table.c.item_id == item_id)
+                .values(**values)
+            )
+
+    def _fetch_item_row(
+        self, conn: Connection, namespace: tuple[str, ...], key: str
+    ) -> Row[Any] | None:
+        item_id = self._item_id(namespace, key)
+        return self._fetch_row_by_item_id(conn, item_id)
+
+    def _fetch_row_by_item_id(self, conn: Connection, item_id: str) -> Row[Any] | None:
+        stmt = (
+            select(self._items_table)
+            .where(self._items_table.c.item_id == item_id)
+            .where(self._live_condition())
+            .limit(1)
+        )
+        return conn.execute(stmt).fetchone()
+
+    def _fetch_candidate_rows(
+        self, conn: Connection, namespace_prefix: tuple[str, ...] | None
+    ) -> list[Row[Any]]:
+        stmt = select(self._items_table).where(self._live_condition())
+        if namespace_prefix is not None:
+            prefix = self._escape_like_pattern(self._encode_namespace(namespace_prefix))
+            stmt = stmt.where(
+                self._items_table.c.namespace_path.like(f"{prefix}%", escape="\\")
+            )
+        stmt = stmt.order_by(
+            self._items_table.c.namespace_path,
+            self._items_table.c.created_at,
+            self._items_table.c.item_id,
+        )
+        return list(conn.execute(stmt).fetchall())
+
+    def _row_to_item(self, row: Row[Any]) -> Item:
+        mapping = row._mapping
+        return Item(
+            namespace=tuple(cast(list[str], mapping["namespace_json"])),
+            key=str(mapping["item_key"]),
+            value=cast(dict[str, Any], mapping["value_json"]),
+            created_at=mapping["created_at"],
+            updated_at=mapping["updated_at"],
+        )
+
+    def _delete_expired_items(self, conn: Connection) -> None:
+        conn.execute(
+            delete(self._items_table).where(
+                and_(
+                    self._items_table.c.expires_at.is_not(None),
+                    self._items_table.c.expires_at <= self._now(),
+                )
+            )
+        )
+
+    def _refresh_ttl(self, conn: Connection, rows: list[Row[Any]]) -> None:
+        now = self._now()
+        for row in rows:
+            ttl_minutes = row._mapping["ttl_minutes"]
+            if ttl_minutes is None:
+                continue
+            conn.execute(
+                update(self._items_table)
+                .where(self._items_table.c.item_id == row._mapping["item_id"])
+                .values(expires_at=self._compute_expires_at(now, ttl_minutes))
+            )
+
+    def _build_index_entries(
+        self,
+        value: dict[str, Any],
+        index: Literal[False] | list[str] | None,
+    ) -> list[dict[str, Any]] | None:
+        if (
+            index is False
+            or self.index_config is None
+            or self.embeddings is None
+        ):
+            return None
+
+        extracted = self._extract_texts(value, index)
+        if not extracted:
+            return None
+
+        texts = [text for _, text in extracted]
+        embeddings = self.embeddings.embed_documents(texts)
+        return [
+            {
+                "path": path,
+                "text": text,
+                "embedding": self._normalize_vector(embedding),
+            }
+            for (path, text), embedding in zip(extracted, embeddings)
+        ]
+
+    async def _abuild_index_entries(
+        self,
+        value: dict[str, Any],
+        index: Literal[False] | list[str] | None,
+    ) -> list[dict[str, Any]] | None:
+        if (
+            index is False
+            or self.index_config is None
+            or self.embeddings is None
+        ):
+            return None
+
+        extracted = self._extract_texts(value, index)
+        if not extracted:
+            return None
+
+        texts = [text for _, text in extracted]
+        embeddings = await self.embeddings.aembed_documents(texts)
+        return [
+            {
+                "path": path,
+                "text": text,
+                "embedding": self._normalize_vector(embedding),
+            }
+            for (path, text), embedding in zip(extracted, embeddings)
+        ]
+
+    def _extract_texts(
+        self, value: dict[str, Any], index: Literal[False] | list[str] | None
+    ) -> list[tuple[str, str]]:
+        if self.index_config is None:
+            return []
+
+        if index is None:
+            paths = cast(list[tuple[str, str | list[str]]], self.index_config[_TOKENIZED_FIELDS_KEY])
+        else:
+            paths = [
+                (path, tokenize_path(path)) if path != "$" else (path, path)
+                for path in index
+            ]
+
+        extracted: list[tuple[str, str]] = []
+        for path, tokenized in paths:
+            texts = get_text_at_path(value, tokenized)
+            if not texts:
+                continue
+            if len(texts) == 1:
+                extracted.append((path, texts[0]))
+            else:
+                extracted.extend((f"{path}.{idx}", text) for idx, text in enumerate(texts))
+        return extracted
+
+    def _matches_filter(
+        self, value: dict[str, Any], filter_value: dict[str, Any] | None
+    ) -> bool:
+        if not filter_value:
+            return True
+        return all(
+            self._compare_values(value.get(key), expected)
+            for key, expected in filter_value.items()
+        )
+
+    def _live_condition(self) -> Any:
+        now = self._now()
+        return or_(
+            self._items_table.c.expires_at.is_(None),
+            self._items_table.c.expires_at > now,
+        )
+
+    def _compute_expires_at(
+        self, now: datetime, ttl_minutes: float | None
+    ) -> datetime | None:
+        if ttl_minutes is None:
+            return None
+        return now + timedelta(minutes=float(ttl_minutes))
+
+    def _item_id(self, namespace: tuple[str, ...], key: str) -> str:
+        digest = hashlib.sha256()
+        digest.update(self._encode_namespace(namespace).encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(str(key).encode("utf-8"))
+        return digest.hexdigest()
+
+    def _encode_namespace(self, namespace: tuple[str, ...]) -> str:
+        return "".join(f"{len(part)}:{part}|" for part in namespace)
+
+    def _escape_like_pattern(self, value: str) -> str:
+        return (
+            value.replace("\\", "\\\\")
+            .replace("%", "\\%")
+            .replace("_", "\\_")
+        )
+
+    def _validate_namespace(self, namespace: tuple[str, ...]) -> None:
+        if not namespace:
+            raise InvalidNamespaceError("Namespace cannot be empty.")
+        for label in namespace:
+            if not isinstance(label, str):
+                raise InvalidNamespaceError(
+                    f"Invalid namespace label '{label}' found in {namespace}. Namespace labels must be strings."
+                )
+            if "." in label:
+                raise InvalidNamespaceError(
+                    f"Invalid namespace label '{label}' found in {namespace}. Namespace labels cannot contain periods ('.')."
+                )
+            if not label:
+                raise InvalidNamespaceError(
+                    f"Namespace labels cannot be empty strings. Got {label} in {namespace}"
+                )
+        if namespace[0] == "langgraph":
+            raise InvalidNamespaceError(
+                f'Root label for namespace cannot be "langgraph". Got: {namespace}'
+            )
+
+    def _does_match(
+        self, match_condition: MatchCondition, key: tuple[str, ...]
+    ) -> bool:
+        path = match_condition.path
+        if len(key) < len(path):
+            return False
+
+        if match_condition.match_type == "prefix":
+            pairs = zip(key, path)
+        elif match_condition.match_type == "suffix":
+            pairs = zip(reversed(key), reversed(path))
+        else:
+            raise ValueError(f"Unsupported match type: {match_condition.match_type}")
+
+        for key_part, path_part in pairs:
+            if path_part == "*":
+                continue
+            if key_part != path_part:
+                return False
+        return True
+
+    def _compare_values(self, item_value: Any, filter_value: Any) -> bool:
+        if isinstance(filter_value, dict):
+            if any(str(key).startswith("$") for key in filter_value):
+                return all(
+                    self._apply_operator(item_value, operator, operand)
+                    for operator, operand in filter_value.items()
+                )
+            if not isinstance(item_value, dict):
+                return False
+            return all(
+                self._compare_values(item_value.get(key), nested)
+                for key, nested in filter_value.items()
+            )
+        if isinstance(filter_value, (list, tuple)):
+            return (
+                isinstance(item_value, (list, tuple))
+                and len(item_value) == len(filter_value)
+                and all(
+                    self._compare_values(actual, expected)
+                    for actual, expected in zip(item_value, filter_value)
+                )
+            )
+        return item_value == filter_value
+
+    def _apply_operator(self, value: Any, operator: str, operand: Any) -> bool:
+        if operator == "$eq":
+            return value == operand
+        if operator == "$ne":
+            return value != operand
+        if operator == "$gt":
+            return float(value) > float(operand)
+        if operator == "$gte":
+            return float(value) >= float(operand)
+        if operator == "$lt":
+            return float(value) < float(operand)
+        if operator == "$lte":
+            return float(value) <= float(operand)
+        raise ValueError(f"Unsupported operator: {operator}")
+
+    def _normalize_vector(self, vector: list[float] | tuple[float, ...] | Any) -> list[float]:
+        return [float(value) for value in vector]
+
+    def _cosine_similarity(
+        self, query_vector: list[float], item_vectors: list[list[float]]
+    ) -> list[float]:
+        query_norm = math.sqrt(sum(value * value for value in query_vector))
+        if query_norm == 0:
+            return [0.0 for _ in item_vectors]
+
+        similarities: list[float] = []
+        for vector in item_vectors:
+            item_norm = math.sqrt(sum(value * value for value in vector))
+            if item_norm == 0:
+                similarities.append(0.0)
+                continue
+            dot = sum(left * right for left, right in zip(query_vector, vector))
+            similarities.append(dot / (query_norm * item_norm))
+        return similarities
+
+    def _now(self) -> datetime:
+        return datetime.now(timezone.utc)

--- a/langchain_oceanbase/vectorstores.py
+++ b/langchain_oceanbase/vectorstores.py
@@ -84,6 +84,12 @@ def _is_empty_result_resource_closed_error(error: ResourceClosedError) -> bool:
     return "does not return rows" in str(error)
 
 
+def _result_id_from_hybrid_result(result: Any, primary_field: str) -> Any | None:
+    if isinstance(result, dict):
+        return result.get(primary_field)
+    return result[2] if len(result) > 2 else result[0]
+
+
 class OceanbaseVectorStore(VectorStore):
     """Oceanbase vector store integration.
 
@@ -1478,11 +1484,9 @@ class OceanbaseVectorStore(VectorStore):
 
         # Process vector results (higher weight for semantic similarity)
         for i, result in enumerate(vector_list):
-            if isinstance(result, dict):
-                doc_id = result.get(self.primary_field)
-            else:
-                # For tuple format: (text_field, metadata_field, primary_field)
-                doc_id = result[2] if len(result) > 2 else result[0]
+            doc_id = _result_id_from_hybrid_result(result, self.primary_field)
+            if doc_id in (None, ""):
+                continue
             # Normalize to 0-1
             vector_score = 1.0 - (i / len(vector_list)) if vector_list else 0
             combined_scores[doc_id] = (
@@ -1491,11 +1495,9 @@ class OceanbaseVectorStore(VectorStore):
 
         # Process full-text results (lower weight for keyword matching)
         for i, result in enumerate(fulltext_list):
-            if isinstance(result, dict):
-                doc_id = result.get(self.primary_field)
-            else:
-                # For tuple format: (text_field, metadata_field, primary_field)
-                doc_id = result[2] if len(result) > 2 else result[0]
+            doc_id = _result_id_from_hybrid_result(result, self.primary_field)
+            if doc_id in (None, ""):
+                continue
             # Normalize to 0-1
             fulltext_score = 1.0 - (i / len(fulltext_list)) if fulltext_list else 0
             combined_scores[doc_id] = (
@@ -1511,20 +1513,16 @@ class OceanbaseVectorStore(VectorStore):
         # Prefer vector results over fulltext results when both exist
         id_to_result = {}
         for result in vector_list:
-            if isinstance(result, dict):
-                result_id = result.get(self.primary_field)
-            else:
-                # For tuple format: (text_field, metadata_field, primary_field)
-                result_id = result[2] if len(result) > 2 else result[0]
+            result_id = _result_id_from_hybrid_result(result, self.primary_field)
+            if result_id in (None, ""):
+                continue
             if result_id not in id_to_result:
                 id_to_result[result_id] = result
         # Add fulltext results only if not already in the mapping
         for result in fulltext_list:
-            if isinstance(result, dict):
-                result_id = result.get(self.primary_field)
-            else:
-                # For tuple format: (text_field, metadata_field, primary_field)
-                result_id = result[2] if len(result) > 2 else result[0]
+            result_id = _result_id_from_hybrid_result(result, self.primary_field)
+            if result_id in (None, ""):
+                continue
             if result_id not in id_to_result:
                 id_to_result[result_id] = result
 
@@ -1587,11 +1585,9 @@ class OceanbaseVectorStore(VectorStore):
             all_converted_results[modality_type] = results_list
 
             for i, result in enumerate(results_list):
-                if isinstance(result, dict):
-                    doc_id = result.get(self.primary_field)
-                else:
-                    # For tuple format: (text_field, metadata_field, primary_field)
-                    doc_id = result[2] if len(result) > 2 else result[0]
+                doc_id = _result_id_from_hybrid_result(result, self.primary_field)
+                if doc_id in (None, ""):
+                    continue
                 # Normalize score based on position (higher position = lower score)
                 normalized_score = 1.0 - (i / len(results_list)) if results_list else 0
                 combined_scores[doc_id] = (
@@ -1610,11 +1606,11 @@ class OceanbaseVectorStore(VectorStore):
         for modality_type in modality_priority:
             if modality_type in all_converted_results:
                 for result in all_converted_results[modality_type]:
-                    if isinstance(result, dict):
-                        result_id = result.get(self.primary_field)
-                    else:
-                        # For tuple format: (text_field, metadata_field, primary_field)
-                        result_id = result[2] if len(result) > 2 else result[0]
+                    result_id = _result_id_from_hybrid_result(
+                        result, self.primary_field
+                    )
+                    if result_id in (None, ""):
+                        continue
                     if result_id not in id_to_result:
                         id_to_result[result_id] = result
 

--- a/langchain_oceanbase/vectorstores.py
+++ b/langchain_oceanbase/vectorstores.py
@@ -84,9 +84,26 @@ def _is_empty_result_resource_closed_error(error: ResourceClosedError) -> bool:
     return "does not return rows" in str(error)
 
 
+def _result_field_from_hybrid_result(
+    result: Any, field_name: str, default: Any = None
+) -> Any:
+    if not isinstance(result, dict):
+        return default
+
+    if field_name in result:
+        return result[field_name]
+
+    qualified_suffix = f".{field_name}"
+    for key, value in result.items():
+        if isinstance(key, str) and key.endswith(qualified_suffix):
+            return value
+
+    return default
+
+
 def _result_id_from_hybrid_result(result: Any, primary_field: str) -> Any | None:
     if isinstance(result, dict):
-        return result.get(primary_field)
+        return _result_field_from_hybrid_result(result, primary_field)
     return result[2] if len(result) > 2 else result[0]
 
 
@@ -1040,9 +1057,13 @@ class OceanbaseVectorStore(VectorStore):
 
             if isinstance(result, dict):
                 # Dictionary format: extract fields by name
-                doc_id = result.get(self.primary_field)
-                page_content = result.get(self.text_field, "")
-                metadata = result.get(self.metadata_field, {})
+                doc_id = _result_field_from_hybrid_result(result, self.primary_field)
+                page_content = _result_field_from_hybrid_result(
+                    result, self.text_field, ""
+                )
+                metadata = _result_field_from_hybrid_result(
+                    result, self.metadata_field, {}
+                )
 
                 # Ensure metadata is a dict, not a JSON string
                 if isinstance(metadata, str):

--- a/langchain_oceanbase/vectorstores.py
+++ b/langchain_oceanbase/vectorstores.py
@@ -84,6 +84,28 @@ def _is_empty_result_resource_closed_error(error: ResourceClosedError) -> bool:
     return "does not return rows" in str(error)
 
 
+def _materialize_result_rows(results: Any) -> List[Any]:
+    """Convert backend search results to a concrete list of rows."""
+    if results is None:
+        return []
+
+    fetchall = getattr(results, "fetchall", None)
+    if callable(fetchall):
+        try:
+            return list(fetchall())
+        except ResourceClosedError as exc:
+            if _is_empty_result_resource_closed_error(exc):
+                return []
+            raise
+
+    try:
+        return list(results)
+    except ResourceClosedError as exc:
+        if _is_empty_result_resource_closed_error(exc):
+            return []
+        raise
+
+
 def _result_field_from_hybrid_result(
     result: Any, field_name: str, default: Any = None
 ) -> Any:
@@ -559,14 +581,7 @@ class OceanbaseVectorStore(VectorStore):
         Returns:
             List[Document] or List[Tuple[Document, float]]: Converted documents
         """
-        try:
-            rows = results.fetchall()
-        except ResourceClosedError as exc:
-            # Embedded SeekDB can surface empty ANN / GET results as a closed
-            # SQLAlchemy result instead of an iterable row set.
-            if _is_empty_result_resource_closed_error(exc):
-                return []
-            raise
+        rows = _materialize_result_rows(results)
 
         if include_score:
             return [
@@ -757,12 +772,7 @@ class OceanbaseVectorStore(VectorStore):
             ],
         )
         documents_by_id: dict[str, Document] = {}
-        try:
-            rows = res.fetchall()
-        except ResourceClosedError as exc:
-            if _is_empty_result_resource_closed_error(exc):
-                return []
-            raise
+        rows = _materialize_result_rows(res)
 
         for row in rows:
             document_id = str(row[2])
@@ -1591,16 +1601,14 @@ class OceanbaseVectorStore(VectorStore):
         for modality_type, results in all_results:
             weight = modality_weights.get(modality_type, 0.1)
 
-            # Convert CursorResult to list if needed
             results_list = []
-            if results:
-                for row in results:
-                    if hasattr(row, "_asdict"):
-                        results_list.append(row._asdict())
-                    elif hasattr(row, "_mapping"):
-                        results_list.append(dict(row._mapping))
-                    else:
-                        results_list.append(row)
+            for row in _materialize_result_rows(results):
+                if hasattr(row, "_asdict"):
+                    results_list.append(row._asdict())
+                elif hasattr(row, "_mapping"):
+                    results_list.append(dict(row._mapping))
+                else:
+                    results_list.append(row)
 
             # Store converted results for later use
             all_converted_results[modality_type] = results_list
@@ -1865,16 +1873,15 @@ class OceanbaseVectorStore(VectorStore):
             single_results = all_results[0][1]
             # Convert CursorResult to list and take first k results
             results_list = []
-            if single_results:
-                for i, row in enumerate(single_results):
-                    if i >= k:
-                        break
-                    if hasattr(row, "_asdict"):
-                        results_list.append(row._asdict())
-                    elif hasattr(row, "_mapping"):
-                        results_list.append(dict(row._mapping))
-                    else:
-                        results_list.append(row)
+            for i, row in enumerate(_materialize_result_rows(single_results)):
+                if i >= k:
+                    break
+                if hasattr(row, "_asdict"):
+                    results_list.append(row._asdict())
+                elif hasattr(row, "_mapping"):
+                    results_list.append(dict(row._mapping))
+                else:
+                    results_list.append(row)
             return self._convert_list_results_to_documents(results_list)
         else:
             # Multiple modalities, combine and rank
@@ -1949,16 +1956,15 @@ class OceanbaseVectorStore(VectorStore):
             # Single modality, convert CursorResult to list
             single_results = all_results[0][1]
             results_list = []
-            if single_results:
-                for i, row in enumerate(single_results):
-                    if i >= k:
-                        break
-                    if hasattr(row, "_asdict"):
-                        results_list.append(row._asdict())
-                    elif hasattr(row, "_mapping"):
-                        results_list.append(dict(row._mapping))
-                    else:
-                        results_list.append(row)
+            for i, row in enumerate(_materialize_result_rows(single_results)):
+                if i >= k:
+                    break
+                if hasattr(row, "_asdict"):
+                    results_list.append(row._asdict())
+                elif hasattr(row, "_mapping"):
+                    results_list.append(dict(row._mapping))
+                else:
+                    results_list.append(row)
             return self._convert_list_results_to_documents(results_list)
         else:
             combined_results = self._combine_multi_modal_results(all_results, k)

--- a/poetry.lock
+++ b/poetry.lock
@@ -551,9 +551,10 @@ files = [
 name = "click"
 version = "8.3.1"
 description = "Composable command line interface toolkit"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"},
     {file = "click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a"},
@@ -591,15 +592,16 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\"", test = "sys_platform == \"win32\""}
+markers = {main = "extra == \"pyseekdb\" and platform_system == \"Windows\"", dev = "sys_platform == \"win32\"", test = "sys_platform == \"win32\""}
 
 [[package]]
 name = "coloredlogs"
 version = "15.0.1"
 description = "Colored terminal output for Python's logging module"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934"},
     {file = "coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0"},
@@ -949,14 +951,16 @@ files = [
     {file = "filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70"},
     {file = "filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694"},
 ]
+markers = {main = "extra == \"pyseekdb\""}
 
 [[package]]
 name = "flatbuffers"
 version = "25.9.23"
 description = "The FlatBuffers serialization format for Python"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "flatbuffers-25.9.23-py2.py3-none-any.whl", hash = "sha256:255538574d6cb6d0a79a17ec8bc0d30985913b87513a01cce8bcdb6b4c44d0e2"},
     {file = "flatbuffers-25.9.23.tar.gz", hash = "sha256:676f9fa62750bb50cf531b42a0a2a118ad8f7f797a511eda12881c016f093b12"},
@@ -1106,9 +1110,10 @@ files = [
 name = "fsspec"
 version = "2025.12.0"
 description = "File-system specification"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "fsspec-2025.12.0-py3-none-any.whl", hash = "sha256:8bf1fe301b7d8acfa6e8571e3b1c3d158f909666642431cc78a1b7b4dbc5ec5b"},
     {file = "fsspec-2025.12.0.tar.gz", hash = "sha256:c505de011584597b1060ff778bb664c1bc022e87921b0e4f10cc9c44f9635973"},
@@ -1221,10 +1226,10 @@ files = [
 name = "hf-xet"
 version = "1.2.0"
 description = "Fast transfer of large files with the Hugging Face Hub."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""
+markers = "extra == \"pyseekdb\" and (platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\")"
 files = [
     {file = "hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649"},
     {file = "hf_xet-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b70218dd548e9840224df5638fdc94bd033552963cfa97f9170829381179c813"},
@@ -1316,9 +1321,10 @@ files = [
 name = "huggingface-hub"
 version = "1.2.2"
 description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
-optional = false
+optional = true
 python-versions = ">=3.9.0"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "huggingface_hub-1.2.2-py3-none-any.whl", hash = "sha256:0f55d7d22058fbf8b29d8095aeee80a7b695aa764f906a21e886c1f87223718f"},
     {file = "huggingface_hub-1.2.2.tar.gz", hash = "sha256:b5b97bd37f4fe5b898a467373044649c94ee32006c032ce8fb835abe9d92ea28"},
@@ -1352,9 +1358,10 @@ typing = ["types-PyYAML", "types-simplejson", "types-toml", "types-tqdm", "types
 name = "humanfriendly"
 version = "10.0"
 description = "Human friendly output for text interfaces using Python"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477"},
     {file = "humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc"},
@@ -2007,9 +2014,10 @@ files = [
 name = "mpmath"
 version = "1.3.0"
 description = "Python library for arbitrary-precision floating-point arithmetic"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"},
     {file = "mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f"},
@@ -2369,9 +2377,10 @@ files = [
 name = "onnxruntime"
 version = "1.23.2"
 description = "ONNX Runtime is a runtime accelerator for Machine Learning models"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3"},
     {file = "onnxruntime-1.23.2-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:b28740f4ecef1738ea8f807461dd541b8287d5650b5be33bca7b474e3cbd1f36"},
@@ -2826,9 +2835,10 @@ files = [
 name = "protobuf"
 version = "6.33.2"
 description = ""
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "protobuf-6.33.2-cp310-abi3-win32.whl", hash = "sha256:87eb388bd2d0f78febd8f4c8779c79247b26a5befad525008e49a6955787ff3d"},
     {file = "protobuf-6.33.2-cp310-abi3-win_amd64.whl", hash = "sha256:fc2a0e8b05b180e5fc0dd1559fe8ebdae21a27e81ac77728fb6c42b12c7419b4"},
@@ -3126,10 +3136,10 @@ windows-terminal = ["colorama (>=0.4.6)"]
 name = "pylibseekdb"
 version = "1.1.0"
 description = "An AI-Native Search Database. Unifies vector, text, structured and semi-structured data in a single engine, enabling hybrid search and in-database AI workflows."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "sys_platform == \"linux\" or sys_platform == \"darwin\" and platform_machine == \"arm64\""
+markers = "(sys_platform == \"linux\" or sys_platform == \"darwin\" and platform_machine == \"arm64\") and extra == \"pyseekdb\""
 files = [
     {file = "pylibseekdb-1.1.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:beaed68943cb59d41c968086eff4efd018291ae5faa66e6b273794a28574d5cb"},
     {file = "pylibseekdb-1.1.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:9902f008118b23a7c74747b013c382342ae245c3ea34b498e831319f81de02e9"},
@@ -3184,6 +3194,7 @@ aiomysql = ">=0.3.2"
 numpy = ">=1.17.0"
 pydantic = ">=2.7.0,<3"
 pymysql = ">=1.1.1"
+pyseekdb = {version = ">=0.1.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"pyseekdb\""}
 sqlalchemy = ">=1.4,<=3"
 sqlglot = ">=26.0.1"
 
@@ -3194,10 +3205,10 @@ pyseekdb = ["pyseekdb (>=0.1.0) ; python_version >= \"3.11\""]
 name = "pyreadline3"
 version = "3.5.4"
 description = "A python implementation of GNU readline."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "sys_platform == \"win32\""
+markers = "extra == \"pyseekdb\" and sys_platform == \"win32\""
 files = [
     {file = "pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6"},
     {file = "pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7"},
@@ -3210,9 +3221,10 @@ dev = ["build", "flake8", "mypy", "pytest", "twine"]
 name = "pyseekdb"
 version = "1.2.0.post2"
 description = "A unified Python client for seekdb that supports embedded, server, and OceanBase."
-optional = false
+optional = true
 python-versions = "<4,>=3.11"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "pyseekdb-1.2.0.post2-py3-none-any.whl", hash = "sha256:2ace81ac64777ec2c615faf4a384f42922ac6b4648a136a010e90e7a1ed81c7a"},
 ]
@@ -3725,9 +3737,10 @@ files = [
 name = "shellingham"
 version = "1.5.4"
 description = "Tool to Detect Surrounding Shell"
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
     {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
@@ -3876,9 +3889,10 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 name = "sympy"
 version = "1.14.0"
 description = "Computer algebra system (CAS) in Python"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5"},
     {file = "sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517"},
@@ -3925,9 +3939,10 @@ test = ["pytest", "tornado (>=4.5)", "typeguard"]
 name = "tokenizers"
 version = "0.22.1"
 description = ""
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "tokenizers-0.22.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:59fdb013df17455e5f950b4b834a7b3ee2e0271e6378ccb33aa74d178b513c73"},
     {file = "tokenizers-0.22.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:8d4e484f7b0827021ac5f9f71d4794aaef62b979ab7608593da22b1d2e3c4edc"},
@@ -3980,9 +3995,10 @@ files = [
 name = "tqdm"
 version = "4.67.1"
 description = "Fast, Extensible Progress Meter"
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2"},
     {file = "tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"},
@@ -4018,9 +4034,10 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,
 name = "typer-slim"
 version = "0.20.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "typer_slim-0.20.0-py3-none-any.whl", hash = "sha256:f42a9b7571a12b97dddf364745d29f12221865acef7a2680065f9bb29c7dc89d"},
     {file = "typer_slim-0.20.0.tar.gz", hash = "sha256:9fc6607b3c6c20f5c33ea9590cbeb17848667c51feee27d9e314a579ab07d1a3"},
@@ -4770,7 +4787,10 @@ files = [
 [package.extras]
 cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and python_version < \"3.14\"", "cffi (>=2.0.0b0) ; platform_python_implementation != \"PyPy\" and python_version >= \"3.14\""]
 
+[extras]
+pyseekdb = ["pylibseekdb", "pyseekdb"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "b30d51e82f6d019927365b1eb557c411268775e967dd3b87e7cc69bdc17bae25"
+content-hash = "7b3f8a21976252aa535291e2ce941bb9d09d661668c9899b3887960b48a46d7a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langchain-oceanbase"
-version = "0.4.0"
+version = "0.5.0"
 description = "An integration package connecting OceanBase and LangChain"
 authors = ["shanhaikang.shk <shanhaikang.shk@oceanbase.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,18 @@ langgraph = ">=0.6.11,<2.0.0"
 langgraph-checkpoint = ">=3.0.1,<5.0.0"
 # >=1.2: unified SeekDB client. Constrain pylibseekdb so the lock resolves to 1.1+ (manylinux + macOS arm64 wheels);
 # 1.0.0.post1 is Linux-wheel-only metadata and breaks Poetry on macOS arm64 / some CI installers.
-pyseekdb = ">=1.2.0.post1,<3"
+pyseekdb = { version = ">=1.2.0.post1,<3", optional = true }
 # Cap <1.2: pylibseekdb 1.2+ wheels are manylinux-only; 1.1.x includes macOS arm64 for local dev + Linux for CI
-pylibseekdb = { version = ">=1.1.0,<1.2", markers = "sys_platform == 'linux' or (sys_platform == 'darwin' and platform_machine == 'arm64')" }
-pyobvector = ">=0.2.25"
+pylibseekdb = { version = ">=1.1.0,<1.2", optional = true, markers = "sys_platform == 'linux' or (sys_platform == 'darwin' and platform_machine == 'arm64')" }
+pyobvector = [
+    { version = ">=0.2.25" },
+    { version = ">=0.2.25", extras = ["pyseekdb"], markers = "extra == 'pyseekdb'" },
+]
 # Pin to safe version for security (CVE-2025-69228 etc.); direct dep so Dependabot can update
 aiohttp = ">=3.13.3"
+
+[tool.poetry.extras]
+pyseekdb = ["pyseekdb", "pylibseekdb"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "T201"]

--- a/tests/integration_tests/_backend_utils.py
+++ b/tests/integration_tests/_backend_utils.py
@@ -62,3 +62,10 @@ def embedded_connection_args() -> dict[str, str]:
 
 def unique_table_name(prefix: str) -> str:
     return f"{prefix}_{uuid.uuid4().hex[:12]}"
+
+
+def is_embedded_seekdb_capacity_error(exc: Exception) -> bool:
+    message = str(exc)
+    return "execute sql failed 5703 Add index failed" in message or (
+        "execute sql failed 4184 Server out of disk space" in message
+    )

--- a/tests/integration_tests/_backend_utils.py
+++ b/tests/integration_tests/_backend_utils.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 import uuid
 
+import pytest
+
 
 def embedded_seekdb_runtime_available() -> bool:
     try:
@@ -69,3 +71,13 @@ def is_embedded_seekdb_capacity_error(exc: Exception) -> bool:
     return "execute sql failed 5703 Add index failed" in message or (
         "execute sql failed 4184 Server out of disk space" in message
     )
+
+
+def skip_embedded_seekdb_capacity_error(
+    exc: Exception,
+    *,
+    backend: str,
+    operation: str,
+) -> None:
+    if backend == "embedded-seekdb" and is_embedded_seekdb_capacity_error(exc):
+        pytest.skip(f"embedded SeekDB capacity exceeded while {operation}: {exc}")

--- a/tests/integration_tests/test_embedding_vectorization.py
+++ b/tests/integration_tests/test_embedding_vectorization.py
@@ -5,9 +5,8 @@ including DefaultEmbeddingFunction and DefaultEmbeddingFunctionAdapter.
 These tests verify that embeddings can be generated correctly without requiring
 database connections.
 
-Note: pyseekdb is a required dependency (defined in pyproject.toml), so these
-tests should always run in CI environments. If pyseekdb is not available,
-the tests will fail, which helps identify dependency issues early.
+Note: pyseekdb is an optional dependency. These tests run only when the
+pyseekdb extra is installed.
 """
 
 import pytest

--- a/tests/integration_tests/test_hybrid_search.py
+++ b/tests/integration_tests/test_hybrid_search.py
@@ -1,13 +1,13 @@
-from __future__ import annotations
-
 """Tests for OceanBase Vector Store hybrid search capabilities."""
+
+from __future__ import annotations
 
 import time
 
 import pytest
 from langchain_core.documents import Document
+from langchain_core.embeddings import FakeEmbeddings
 
-from langchain_oceanbase.embedding_utils import DefaultEmbeddingFunctionAdapter
 from langchain_oceanbase.exceptions import (
     OceanBaseConfigurationError,
     OceanBaseVectorDimensionError,
@@ -22,7 +22,7 @@ class TestHybridSearch:
     @pytest.fixture
     def embeddings(self):
         """Standard embeddings for testing."""
-        return DefaultEmbeddingFunctionAdapter()
+        return FakeEmbeddings(size=384)
 
     @pytest.fixture
     def hybrid_store_factory(

--- a/tests/integration_tests/test_store.py
+++ b/tests/integration_tests/test_store.py
@@ -1,0 +1,125 @@
+# mypy: disable-error-code="import-untyped,no-untyped-def"
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+from langchain_core.embeddings import Embeddings
+
+from langchain_oceanbase import OceanBaseStore
+from tests.integration_tests._backend_utils import unique_table_name
+
+
+class DummyEmbeddings(Embeddings):
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [self._embed(text) for text in texts]
+
+    def embed_query(self, text: str) -> list[float]:
+        return self._embed(text)
+
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
+        return self.embed_documents(texts)
+
+    async def aembed_query(self, text: str) -> list[float]:
+        return self.embed_query(text)
+
+    def _embed(self, text: str) -> list[float]:
+        lowered = text.lower()
+        return [
+            1.0 if "python" in lowered else 0.0,
+            1.0 if "java" in lowered else 0.0,
+            float((len(lowered) % 11) + 1),
+        ]
+
+
+@pytest.fixture
+def store_factory(
+    integration_connection_args: dict[str, str],
+    integration_client_kwargs: dict[str, Any],
+):
+    stores: list[OceanBaseStore] = []
+
+    def factory(**kwargs: Any) -> OceanBaseStore:
+        store = OceanBaseStore(
+            connection_args=integration_connection_args,
+            index={"dims": 3, "embed": DummyEmbeddings(), "fields": ["text"]},
+            ttl_config={"refresh_on_read": True},
+            table_name=unique_table_name("langgraph_store"),
+            **integration_client_kwargs,
+            **kwargs,
+        )
+        store.setup()
+        stores.append(store)
+        return store
+
+    yield factory
+
+    for store in stores:
+        try:
+            store._metadata.drop_all(store.obvector.engine, tables=[store._items_table])
+        except Exception:
+            pass
+
+
+def test_store_round_trip_and_namespace_listing(store_factory) -> None:
+    store = store_factory()
+
+    store.put(("users", "1", "prefs"), "theme", {"text": "python preferences"})
+    store.put(("users", "1", "docs"), "guide", {"text": "java guide"})
+    store.put(("users", "2", "prefs"), "theme", {"text": "python notes"})
+
+    item = store.get(("users", "1", "prefs"), "theme")
+    namespaced = store.list_namespaces(prefix=("users", "*"), max_depth=2)
+    filtered = store.search(("users",), filter={"text": "python notes"})
+
+    assert item is not None
+    assert item.value["text"] == "python preferences"
+    assert namespaced == [("users", "1"), ("users", "2")]
+    assert [result.key for result in filtered] == ["theme"]
+
+
+def test_store_namespace_prefix_metacharacters_are_literal(store_factory) -> None:
+    store = store_factory()
+
+    store.put(("team_%", "alpha"), "literal-percent", {"text": "python literal"})
+    store.put(("teamX", "alpha"), "wildcard-candidate", {"text": "python wildcard"})
+    store.put(("team__", "beta"), "literal-underscore", {"text": "python underscore"})
+    store.put(("teamZZ", "beta"), "underscore-candidate", {"text": "python wildcard"})
+
+    percent_results = store.search(("team_%",), limit=10)
+    underscore_results = store.search(("team__",), limit=10)
+
+    assert [result.key for result in percent_results] == ["literal-percent"]
+    assert [result.key for result in underscore_results] == ["literal-underscore"]
+
+
+def test_store_semantic_search_and_ttl(store_factory) -> None:
+    store = store_factory()
+
+    store.put(("memories",), "python", {"text": "python memory"})
+    store.put(("memories",), "java", {"text": "java memory"})
+    store.put(("memories",), "ttl", {"text": "python ttl"}, ttl=0.002)
+
+    ranked = store.search(("memories",), query="python", limit=2)
+    assert [result.key for result in ranked] == ["python", "java"]
+
+    time.sleep(0.03)
+    assert store.get(("memories",), "ttl", refresh_ttl=True) is not None
+    time.sleep(0.03)
+    assert store.get(("memories",), "ttl", refresh_ttl=False) is not None
+    time.sleep(0.12)
+    assert store.get(("memories",), "ttl", refresh_ttl=False) is None
+
+
+@pytest.mark.asyncio
+async def test_store_async_round_trip(store_factory) -> None:
+    store = store_factory()
+
+    await store.aput(("async",), "note", {"text": "python async"})
+    item = await store.aget(("async",), "note")
+    results = await store.asearch(("async",), query="python", limit=1)
+
+    assert item is not None
+    assert item.key == "note"
+    assert [result.key for result in results] == ["note"]

--- a/tests/integration_tests/test_store.py
+++ b/tests/integration_tests/test_store.py
@@ -118,20 +118,26 @@ def test_store_namespace_prefix_metacharacters_are_literal(store_factory) -> Non
 
 def test_store_semantic_search_and_ttl(store_factory) -> None:
     store = store_factory()
-    started = time.monotonic()
 
     store.put(("memories",), "python", {"text": "python memory"})
     store.put(("memories",), "java", {"text": "java memory"})
-    store.put(("memories",), "ttl", {"text": "ttl marker"}, ttl=0.03)
+    store.put(("memories",), "ttl", {"text": "ttl marker"}, ttl=0.05)
+    store.put(("memories",), "ttl-control", {"text": "ttl control"}, ttl=0.05)
 
     ranked = store.search(("memories",), query="python", limit=2)
     assert [result.key for result in ranked] == ["python", "java"]
 
-    time.sleep(0.5)
+    time.sleep(1.0)
     assert store.get(("memories",), "ttl", refresh_ttl=True) is not None
 
-    while time.monotonic() - started < 2.2:
-        time.sleep(0.1)
+    control_expiration_deadline = time.monotonic() + 4.5
+    while time.monotonic() < control_expiration_deadline:
+        if store.get(("memories",), "ttl-control", refresh_ttl=False) is None:
+            break
+        time.sleep(0.2)
+    else:
+        pytest.fail("Control TTL item did not expire in time")
+
     assert store.get(("memories",), "ttl", refresh_ttl=False) is not None
 
     expiration_deadline = time.monotonic() + 3.5

--- a/tests/integration_tests/test_store.py
+++ b/tests/integration_tests/test_store.py
@@ -99,16 +99,16 @@ def test_store_semantic_search_and_ttl(store_factory) -> None:
 
     store.put(("memories",), "python", {"text": "python memory"})
     store.put(("memories",), "java", {"text": "java memory"})
-    store.put(("memories",), "ttl", {"text": "ttl marker"}, ttl=0.005)
+    store.put(("memories",), "ttl", {"text": "ttl marker"}, ttl=0.03)
 
     ranked = store.search(("memories",), query="python", limit=2)
     assert [result.key for result in ranked] == ["python", "java"]
 
-    time.sleep(0.05)
+    time.sleep(0.2)
     assert store.get(("memories",), "ttl", refresh_ttl=True) is not None
-    time.sleep(0.05)
+    time.sleep(0.2)
     assert store.get(("memories",), "ttl", refresh_ttl=False) is not None
-    time.sleep(0.35)
+    time.sleep(2.0)
     assert store.get(("memories",), "ttl", refresh_ttl=False) is None
 
 

--- a/tests/integration_tests/test_store.py
+++ b/tests/integration_tests/test_store.py
@@ -8,7 +8,10 @@ import pytest
 from langchain_core.embeddings import Embeddings
 
 from langchain_oceanbase import OceanBaseStore
-from tests.integration_tests._backend_utils import unique_table_name
+from tests.integration_tests._backend_utils import (
+    is_embedded_seekdb_capacity_error,
+    unique_table_name,
+)
 
 
 class DummyEmbeddings(Embeddings):
@@ -35,6 +38,7 @@ class DummyEmbeddings(Embeddings):
 
 @pytest.fixture
 def store_factory(
+    integration_backend_name: str,
     integration_connection_args: dict[str, str],
     integration_client_kwargs: dict[str, Any],
 ):
@@ -49,7 +53,17 @@ def store_factory(
             **integration_client_kwargs,
             **kwargs,
         )
-        store.setup()
+        try:
+            store.setup()
+        except Exception as exc:
+            if (
+                integration_backend_name == "embedded-seekdb"
+                and is_embedded_seekdb_capacity_error(exc)
+            ):
+                pytest.skip(
+                    f"embedded SeekDB capacity exceeded while creating store indexes: {exc}"
+                )
+            raise
         stores.append(store)
         return store
 

--- a/tests/integration_tests/test_store.py
+++ b/tests/integration_tests/test_store.py
@@ -29,7 +29,7 @@ class DummyEmbeddings(Embeddings):
         return [
             1.0 if "python" in lowered else 0.0,
             1.0 if "java" in lowered else 0.0,
-            float((len(lowered) % 11) + 1),
+            1.0 if "python" not in lowered and "java" not in lowered else 0.0,
         ]
 
 
@@ -99,16 +99,16 @@ def test_store_semantic_search_and_ttl(store_factory) -> None:
 
     store.put(("memories",), "python", {"text": "python memory"})
     store.put(("memories",), "java", {"text": "java memory"})
-    store.put(("memories",), "ttl", {"text": "python ttl"}, ttl=0.002)
+    store.put(("memories",), "ttl", {"text": "ttl marker"}, ttl=0.005)
 
     ranked = store.search(("memories",), query="python", limit=2)
     assert [result.key for result in ranked] == ["python", "java"]
 
-    time.sleep(0.03)
+    time.sleep(0.05)
     assert store.get(("memories",), "ttl", refresh_ttl=True) is not None
-    time.sleep(0.03)
+    time.sleep(0.05)
     assert store.get(("memories",), "ttl", refresh_ttl=False) is not None
-    time.sleep(0.12)
+    time.sleep(0.35)
     assert store.get(("memories",), "ttl", refresh_ttl=False) is None
 
 

--- a/tests/integration_tests/test_store.py
+++ b/tests/integration_tests/test_store.py
@@ -93,6 +93,14 @@ def test_store_round_trip_and_namespace_listing(store_factory) -> None:
     assert [result.key for result in filtered] == ["theme"]
 
 
+def test_store_empty_backend_results_behave_like_empty_store(store_factory) -> None:
+    store = store_factory()
+
+    assert store.get(("missing",), "item") is None
+    assert store.search(("missing",), limit=10) == []
+    assert store.list_namespaces(prefix=("missing",), max_depth=2) == []
+
+
 def test_store_namespace_prefix_metacharacters_are_literal(store_factory) -> None:
     store = store_factory()
 
@@ -110,6 +118,7 @@ def test_store_namespace_prefix_metacharacters_are_literal(store_factory) -> Non
 
 def test_store_semantic_search_and_ttl(store_factory) -> None:
     store = store_factory()
+    started = time.monotonic()
 
     store.put(("memories",), "python", {"text": "python memory"})
     store.put(("memories",), "java", {"text": "java memory"})
@@ -118,12 +127,20 @@ def test_store_semantic_search_and_ttl(store_factory) -> None:
     ranked = store.search(("memories",), query="python", limit=2)
     assert [result.key for result in ranked] == ["python", "java"]
 
-    time.sleep(0.2)
+    time.sleep(0.5)
     assert store.get(("memories",), "ttl", refresh_ttl=True) is not None
-    time.sleep(0.2)
+
+    while time.monotonic() - started < 2.2:
+        time.sleep(0.1)
     assert store.get(("memories",), "ttl", refresh_ttl=False) is not None
-    time.sleep(2.0)
-    assert store.get(("memories",), "ttl", refresh_ttl=False) is None
+
+    expiration_deadline = time.monotonic() + 3.5
+    while time.monotonic() < expiration_deadline:
+        if store.get(("memories",), "ttl", refresh_ttl=False) is None:
+            break
+        time.sleep(0.2)
+    else:
+        pytest.fail("TTL item did not expire after the refreshed TTL window")
 
 
 @pytest.mark.asyncio

--- a/tests/integration_tests/test_vectorstores.py
+++ b/tests/integration_tests/test_vectorstores.py
@@ -12,7 +12,7 @@ from langchain_tests.integration_tests import (
 from langchain_oceanbase.embedding_utils import DefaultEmbeddingFunctionAdapter
 from langchain_oceanbase.vectorstores import OceanbaseVectorStore
 from tests.integration_tests._backend_utils import (
-    is_embedded_seekdb_capacity_error,
+    skip_embedded_seekdb_capacity_error,
     unique_table_name,
     use_embedded_seekdb,
 )
@@ -52,13 +52,11 @@ def vectorstore_factory(
                 **kwargs,
             )
         except Exception as exc:
-            if (
-                seekdb_capable_backend == "embedded-seekdb"
-                and is_embedded_seekdb_capacity_error(exc)
-            ):
-                pytest.skip(
-                    f"embedded SeekDB capacity exceeded while creating vector index: {exc}"
-                )
+            skip_embedded_seekdb_capacity_error(
+                exc,
+                backend=seekdb_capable_backend,
+                operation="creating vector index",
+            )
             raise
         stores.append(store)
         return store
@@ -180,6 +178,7 @@ class TestOceanbaseVectorStoreIntegration:
     def test_from_texts_integration(
         self,
         vectorstore,
+        seekdb_capable_backend: str,
         integration_client_kwargs: dict[str, str],
         default_vector_index_type: str,
     ):
@@ -187,18 +186,26 @@ class TestOceanbaseVectorStoreIntegration:
         texts = ["Integration test 1", "Integration test 2", "Integration test 3"]
         metadatas = [{"source": "int1"}, {"source": "int2"}, {"source": "int3"}]
 
-        new_vectorstore = OceanbaseVectorStore.from_texts(
-            texts=texts,
-            embedding=vectorstore.embedding_function,
-            metadatas=metadatas,
-            table_name=unique_table_name("from_texts_integration"),
-            connection_args=vectorstore.connection_args,
-            vidx_metric_type="l2",
-            index_type=default_vector_index_type,
-            drop_old=True,
-            embedding_dim=384,
-            **integration_client_kwargs,
-        )
+        try:
+            new_vectorstore = OceanbaseVectorStore.from_texts(
+                texts=texts,
+                embedding=vectorstore.embedding_function,
+                metadatas=metadatas,
+                table_name=unique_table_name("from_texts_integration"),
+                connection_args=vectorstore.connection_args,
+                vidx_metric_type="l2",
+                index_type=default_vector_index_type,
+                drop_old=True,
+                embedding_dim=384,
+                **integration_client_kwargs,
+            )
+        except Exception as exc:
+            skip_embedded_seekdb_capacity_error(
+                exc,
+                backend=seekdb_capable_backend,
+                operation="creating vector index via from_texts",
+            )
+            raise
 
         # Verify all texts are present by searching with empty string
         all_results = new_vectorstore.similarity_search("", k=10)

--- a/tests/integration_tests/test_vectorstores.py
+++ b/tests/integration_tests/test_vectorstores.py
@@ -11,7 +11,11 @@ from langchain_tests.integration_tests import (
 
 from langchain_oceanbase.embedding_utils import DefaultEmbeddingFunctionAdapter
 from langchain_oceanbase.vectorstores import OceanbaseVectorStore
-from tests.integration_tests._backend_utils import unique_table_name, use_embedded_seekdb
+from tests.integration_tests._backend_utils import (
+    is_embedded_seekdb_capacity_error,
+    unique_table_name,
+    use_embedded_seekdb,
+)
 
 EMBEDDING_SIZE = 6
 
@@ -34,17 +38,28 @@ def vectorstore_factory(
         index_type: str | None = None,
         **kwargs,
     ) -> OceanbaseVectorStore:
-        store = OceanbaseVectorStore(
-            embedding_function=embedding_function or DefaultEmbeddingFunctionAdapter(),
-            table_name=table_name or unique_table_name("integration_test"),
-            connection_args=integration_connection_args,
-            vidx_metric_type=vidx_metric_type,
-            index_type=index_type or default_vector_index_type,
-            drop_old=True,
-            embedding_dim=embedding_dim,
-            **integration_client_kwargs,
-            **kwargs,
-        )
+        try:
+            store = OceanbaseVectorStore(
+                embedding_function=embedding_function
+                or DefaultEmbeddingFunctionAdapter(),
+                table_name=table_name or unique_table_name("integration_test"),
+                connection_args=integration_connection_args,
+                vidx_metric_type=vidx_metric_type,
+                index_type=index_type or default_vector_index_type,
+                drop_old=True,
+                embedding_dim=embedding_dim,
+                **integration_client_kwargs,
+                **kwargs,
+            )
+        except Exception as exc:
+            if (
+                seekdb_capable_backend == "embedded-seekdb"
+                and is_embedded_seekdb_capacity_error(exc)
+            ):
+                pytest.skip(
+                    f"embedded SeekDB capacity exceeded while creating vector index: {exc}"
+                )
+            raise
         stores.append(store)
         return store
 

--- a/tests/integration_tests/test_vectorstores.py
+++ b/tests/integration_tests/test_vectorstores.py
@@ -4,12 +4,12 @@ from typing import Generator
 
 import pytest
 from langchain_core.documents import Document
+from langchain_core.embeddings import FakeEmbeddings
 from langchain_core.vectorstores import VectorStore
 from langchain_tests.integration_tests import (
     VectorStoreIntegrationTests,
 )
 
-from langchain_oceanbase.embedding_utils import DefaultEmbeddingFunctionAdapter
 from langchain_oceanbase.vectorstores import OceanbaseVectorStore
 from tests.integration_tests._backend_utils import (
     skip_embedded_seekdb_capacity_error,
@@ -40,8 +40,7 @@ def vectorstore_factory(
     ) -> OceanbaseVectorStore:
         try:
             store = OceanbaseVectorStore(
-                embedding_function=embedding_function
-                or DefaultEmbeddingFunctionAdapter(),
+                embedding_function=embedding_function or FakeEmbeddings(size=384),
                 table_name=table_name or unique_table_name("integration_test"),
                 connection_args=integration_connection_args,
                 vidx_metric_type=vidx_metric_type,
@@ -125,8 +124,7 @@ class TestOceanbaseVectorStoreIntegration:
         ids = vectorstore.add_documents(documents)
         assert len(ids) == 3
 
-        # Test that we can retrieve all documents by searching with empty string
-        # This should return all documents since DefaultEmbeddingFunctionAdapter generates consistent embeddings
+        # Test that we can retrieve all documents by searching with empty string.
         all_results = vectorstore.similarity_search("", k=10)
         assert len(all_results) >= 3
 

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -144,12 +144,11 @@ def test_basic_functionality() -> bool:
 
     try:
         from langchain_core.documents import Document
+        from langchain_core.embeddings import FakeEmbeddings
 
-        from langchain_oceanbase.embedding_utils import DefaultEmbeddingFunctionAdapter
         from langchain_oceanbase.vectorstores import OceanbaseVectorStore
 
-        # Create embeddings using DefaultEmbeddingFunctionAdapter
-        embeddings = DefaultEmbeddingFunctionAdapter()
+        embeddings = FakeEmbeddings(size=384)
 
         connection_args = _ci_connection_args()
 
@@ -238,11 +237,11 @@ def test_metric_types() -> bool:
 
     try:
         from langchain_core.documents import Document
+        from langchain_core.embeddings import FakeEmbeddings
 
-        from langchain_oceanbase.embedding_utils import DefaultEmbeddingFunctionAdapter
         from langchain_oceanbase.vectorstores import OceanbaseVectorStore
 
-        embeddings = DefaultEmbeddingFunctionAdapter()
+        embeddings = FakeEmbeddings(size=384)
 
         connection_args = _ci_connection_args()
 
@@ -290,10 +289,11 @@ def test_from_texts() -> bool:
     print("\nTesting from_texts method...")
 
     try:
-        from langchain_oceanbase.embedding_utils import DefaultEmbeddingFunctionAdapter
+        from langchain_core.embeddings import FakeEmbeddings
+
         from langchain_oceanbase.vectorstores import OceanbaseVectorStore
 
-        embeddings = DefaultEmbeddingFunctionAdapter()
+        embeddings = FakeEmbeddings(size=384)
 
         connection_args = _ci_connection_args()
 

--- a/tests/unit_tests/test_backend_utils.py
+++ b/tests/unit_tests/test_backend_utils.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.integration_tests._backend_utils import skip_embedded_seekdb_capacity_error
+
+
+def test_skip_embedded_seekdb_capacity_error_skips_embedded_index_exhaustion() -> None:
+    with pytest.raises(pytest.skip.Exception):
+        skip_embedded_seekdb_capacity_error(
+            RuntimeError("execute sql failed 5703 Add index failed"),
+            backend="embedded-seekdb",
+            operation="creating vector index",
+        )

--- a/tests/unit_tests/test_chat_message_histories.py
+++ b/tests/unit_tests/test_chat_message_histories.py
@@ -1,0 +1,32 @@
+from unittest.mock import MagicMock, patch
+
+from sqlalchemy.exc import ResourceClosedError
+
+from langchain_oceanbase.chat_message_histories import OceanBaseChatMessageHistory
+
+
+def test_messages_returns_empty_list_when_backend_closes_empty_result() -> None:
+    mock_client = MagicMock()
+    mock_client.check_table_exists.return_value = True
+    mock_result = MagicMock()
+    mock_result.fetchall.side_effect = ResourceClosedError(
+        "This result object does not return rows. It has been closed automatically."
+    )
+    mock_client.get.return_value = mock_result
+
+    with patch(
+        "langchain_oceanbase.chat_message_histories.ObVecClient",
+        return_value=mock_client,
+    ):
+        history = OceanBaseChatMessageHistory(
+            session_id="test-session",
+            connection_args={
+                "host": "localhost",
+                "port": "2881",
+                "user": "root",
+                "password": "",
+                "db_name": "test",
+            },
+        )
+
+    assert history.messages == []

--- a/tests/unit_tests/test_embedding_utils.py
+++ b/tests/unit_tests/test_embedding_utils.py
@@ -35,6 +35,23 @@ else:
     DefaultEmbeddingFunctionAdapter = None
 
 
+def test_embedding_module_imports_without_pyseekdb() -> None:
+    """The module should stay importable even when the optional extra is absent."""
+    assert embedding_utils_module is not None
+    if PYSEEKDB_AVAILABLE:
+        assert embedding_utils_module.DefaultEmbeddingFunction is not None
+    else:
+        assert embedding_utils_module.DefaultEmbeddingFunction is None
+
+
+@pytest.mark.skipif(PYSEEKDB_AVAILABLE, reason="pyseekdb is installed")
+def test_adapter_raises_clear_error_without_pyseekdb() -> None:
+    """Missing optional dependencies should fail with an actionable message."""
+    assert embedding_utils_module is not None
+    with pytest.raises(ImportError, match="langchain-oceanbase\\[pyseekdb\\]"):
+        embedding_utils_module.DefaultEmbeddingFunctionAdapter()
+
+
 @pytest.mark.skipif(
     PySeekDBDefaultEmbeddingFunction is None or DefaultEmbeddingFunction is None,
     reason="pyseekdb is not installed",
@@ -250,12 +267,13 @@ class TestDefaultEmbeddingFunctionAdapterErrorHandling:
         reason="pyseekdb is not installed or module cannot be imported, cannot test error handling",
     )
     def test_adapter_import_error_when_default_is_none(self):
-        """Test ImportError when DefaultEmbeddingFunction is None."""
+        """Test ImportError when pyseekdb is unavailable."""
         import unittest.mock
 
-        # Use mock instead of reload because reload will re-import from pyseekdb
         with unittest.mock.patch.object(
-            embedding_utils_module, "DefaultEmbeddingFunction", None
+            embedding_utils_module,
+            "DefaultEmbeddingFunction",
+            None,
         ):
             with pytest.raises(ImportError, match="pyseekdb is not installed"):
                 embedding_utils_module.DefaultEmbeddingFunctionAdapter()

--- a/tests/unit_tests/test_store.py
+++ b/tests/unit_tests/test_store.py
@@ -35,6 +35,20 @@ class DummyEmbeddings(Embeddings):
         ]
 
 
+class AsyncOnlyEmbeddings(Embeddings):
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        raise RuntimeError("sync embed_documents called")
+
+    def embed_query(self, text: str) -> list[float]:
+        raise RuntimeError("sync embed_query called")
+
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [[1.0] for _ in texts]
+
+    async def aembed_query(self, text: str) -> list[float]:
+        return [1.0]
+
+
 @pytest.fixture
 def store() -> OceanBaseStore:
     fake_client = SimpleNamespace(
@@ -76,6 +90,7 @@ def test_search_honors_filters_and_comparison_operators(store: OceanBaseStore) -
     store.put(("docs", "team-a"), "one", {"text": "python guide", "age": 12})
     store.put(("docs", "team-a"), "two", {"text": "java guide", "age": 8})
     store.put(("docs", "team-b"), "three", {"text": "python tips", "age": 20})
+    store.put(("docs", "team-c"), "four", {"text": "python misc"})
 
     results = store.search(
         ("docs",),
@@ -118,6 +133,19 @@ def test_semantic_search_ranks_indexed_items_and_fills_with_scoreless_items(
     assert mixed[2].score is None
 
 
+def test_semantic_search_offset_advances_into_scoreless_items(
+    store: OceanBaseStore,
+) -> None:
+    store.put(("memories",), "python", {"text": "python patterns"})
+    store.put(("memories",), "java", {"text": "java patterns"})
+    store.put(("memories",), "scoreless-a", {"text": "other a"}, index=False)
+    store.put(("memories",), "scoreless-b", {"text": "other b"}, index=False)
+
+    page = store.search(("memories",), query="python", limit=1, offset=3)
+
+    assert [result.key for result in page] == ["scoreless-b"]
+
+
 def test_list_namespaces_supports_prefix_suffix_and_depth(store: OceanBaseStore) -> None:
     store.put(("users", "1", "prefs"), "a", {"text": "python"})
     store.put(("users", "1", "docs"), "b", {"text": "java"})
@@ -151,15 +179,15 @@ def test_store_treats_empty_closed_results_as_missing_rows(store: OceanBaseStore
 
 
 def test_ttl_expires_items_and_refreshes_on_read(store: OceanBaseStore) -> None:
-    store.put(("ttl",), "ephemeral", {"text": "ttl marker"}, ttl=0.005)
+    store.put(("ttl",), "ephemeral", {"text": "ttl marker"}, ttl=0.01)
 
-    time.sleep(0.05)
+    time.sleep(0.25)
     assert store.get(("ttl",), "ephemeral", refresh_ttl=True) is not None
 
-    time.sleep(0.05)
+    time.sleep(0.45)
     assert store.get(("ttl",), "ephemeral", refresh_ttl=False) is not None
 
-    time.sleep(0.35)
+    time.sleep(0.25)
     assert store.get(("ttl",), "ephemeral", refresh_ttl=False) is None
 
 
@@ -176,20 +204,29 @@ async def test_async_store_methods_round_trip(store: OceanBaseStore) -> None:
 
 
 @pytest.mark.asyncio
-async def test_abatch_offloads_sync_batch_work(store: OceanBaseStore) -> None:
-    calls: list[tuple[object, tuple[object, ...]]] = []
+async def test_async_store_methods_use_async_embeddings() -> None:
+    fake_client = SimpleNamespace(
+        engine=create_engine(
+            "sqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        ),
+        metadata_obj=MetaData(),
+    )
+    with patch("langchain_oceanbase.store.ObVecClient", return_value=fake_client):
+        store = OceanBaseStore(
+            connection_args={
+                "host": "localhost",
+                "port": "2881",
+                "user": "root",
+                "password": "",
+                "db_name": "test",
+            },
+            index={"dims": 1, "embed": AsyncOnlyEmbeddings(), "fields": ["text"]},
+        )
+        store.setup()
 
-    async def fake_to_thread(func: object, /, *args: object, **kwargs: object) -> object:
-        calls.append((func, args))
-        assert kwargs == {}
-        return "sentinel"
+        await store.aput(("async",), "doc", {"text": "python async"})
+        results = await store.asearch(("async",), query="python", limit=1)
 
-    with patch("langchain_oceanbase.store.asyncio.to_thread", side_effect=fake_to_thread):
-        result = await store.abatch([])
-
-    assert result == "sentinel"
-    assert len(calls) == 1
-    func, args = calls[0]
-    assert getattr(func, "__self__", None) is store
-    assert getattr(func, "__func__", None) is OceanBaseStore.batch
-    assert args == ([],)
+    assert [result.key for result in results] == ["doc"]

--- a/tests/unit_tests/test_store.py
+++ b/tests/unit_tests/test_store.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 from langchain_core.embeddings import Embeddings
 from sqlalchemy import MetaData, create_engine
+from sqlalchemy.exc import ResourceClosedError
 from sqlalchemy.pool import StaticPool
 
 from langchain_oceanbase.store import OceanBaseStore
@@ -128,6 +129,25 @@ def test_list_namespaces_supports_prefix_suffix_and_depth(store: OceanBaseStore)
 
     assert by_prefix == [("users", "1"), ("users", "2")]
     assert by_suffix == [("users", "1", "prefs"), ("users", "2", "prefs")]
+
+
+def test_store_treats_empty_closed_results_as_missing_rows(store: OceanBaseStore) -> None:
+    mock_result = SimpleNamespace(
+        fetchone=lambda: (_ for _ in ()).throw(
+            ResourceClosedError(
+                "This result object does not return rows. It has been closed automatically."
+            )
+        ),
+        fetchall=lambda: (_ for _ in ()).throw(
+            ResourceClosedError(
+                "This result object does not return rows. It has been closed automatically."
+            )
+        ),
+    )
+    mock_conn = SimpleNamespace(execute=lambda stmt: mock_result)
+
+    assert store._fetch_row_by_item_id(mock_conn, "missing") is None
+    assert store._fetch_candidate_rows(mock_conn, None) == []
 
 
 def test_ttl_expires_items_and_refreshes_on_read(store: OceanBaseStore) -> None:

--- a/tests/unit_tests/test_store.py
+++ b/tests/unit_tests/test_store.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from langchain_core.embeddings import Embeddings
+from sqlalchemy import MetaData, create_engine
+
+from langchain_oceanbase.store import OceanBaseStore
+
+
+class DummyEmbeddings(Embeddings):
+    def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        return [self._embed(text) for text in texts]
+
+    def embed_query(self, text: str) -> list[float]:
+        return self._embed(text)
+
+    async def aembed_documents(self, texts: list[str]) -> list[list[float]]:
+        return self.embed_documents(texts)
+
+    async def aembed_query(self, text: str) -> list[float]:
+        return self.embed_query(text)
+
+    def _embed(self, text: str) -> list[float]:
+        lowered = text.lower()
+        return [
+            1.0 if "python" in lowered else 0.0,
+            1.0 if "java" in lowered else 0.0,
+            float((len(lowered) % 7) + 1),
+        ]
+
+
+@pytest.fixture
+def store() -> OceanBaseStore:
+    fake_client = SimpleNamespace(
+        engine=create_engine("sqlite:///:memory:"),
+        metadata_obj=MetaData(),
+    )
+    with patch("langchain_oceanbase.store.ObVecClient", return_value=fake_client):
+        instance = OceanBaseStore(
+            connection_args={
+                "host": "localhost",
+                "port": "2881",
+                "user": "root",
+                "password": "",
+                "db_name": "test",
+            },
+            index={"dims": 3, "embed": DummyEmbeddings(), "fields": ["text"]},
+            ttl_config={"refresh_on_read": True},
+        )
+        instance.setup()
+        return instance
+
+
+def test_put_and_get_round_trip(store: OceanBaseStore) -> None:
+    store.put(("users", "123"), "prefs", {"theme": "dark", "age": 12})
+
+    item = store.get(("users", "123"), "prefs")
+
+    assert item is not None
+    assert item.namespace == ("users", "123")
+    assert item.key == "prefs"
+    assert item.value == {"theme": "dark", "age": 12}
+
+
+def test_search_honors_filters_and_comparison_operators(store: OceanBaseStore) -> None:
+    store.put(("docs", "team-a"), "one", {"text": "python guide", "age": 12})
+    store.put(("docs", "team-a"), "two", {"text": "java guide", "age": 8})
+    store.put(("docs", "team-b"), "three", {"text": "python tips", "age": 20})
+
+    results = store.search(
+        ("docs",),
+        filter={"age": {"$gte": 10}},
+        limit=10,
+    )
+
+    assert [result.key for result in results] == ["one", "three"]
+
+
+def test_search_treats_namespace_prefix_metacharacters_as_literals(
+    store: OceanBaseStore,
+) -> None:
+    store.put(("team_%", "alpha"), "literal-percent", {"text": "python literal"})
+    store.put(("teamX", "alpha"), "wildcard-candidate", {"text": "python wildcard"})
+    store.put(("team__", "beta"), "literal-underscore", {"text": "python underscore"})
+    store.put(("teamZZ", "beta"), "underscore-candidate", {"text": "python wildcard"})
+
+    percent_results = store.search(("team_%",), limit=10)
+    underscore_results = store.search(("team__",), limit=10)
+
+    assert [result.key for result in percent_results] == ["literal-percent"]
+    assert [result.key for result in underscore_results] == ["literal-underscore"]
+
+
+def test_semantic_search_ranks_indexed_items_and_fills_with_scoreless_items(
+    store: OceanBaseStore,
+) -> None:
+    store.put(("memories",), "python", {"text": "python patterns"})
+    store.put(("memories",), "scoreless", {"text": "python hidden"}, index=False)
+    store.put(("memories",), "java", {"text": "java patterns"})
+
+    results = store.search(("memories",), query="python", limit=2)
+
+    assert [result.key for result in results] == ["python", "java"]
+    assert results[0].score is not None
+
+    mixed = store.search(("memories",), query="python", limit=3)
+    assert [result.key for result in mixed] == ["python", "java", "scoreless"]
+    assert mixed[2].score is None
+
+
+def test_list_namespaces_supports_prefix_suffix_and_depth(store: OceanBaseStore) -> None:
+    store.put(("users", "1", "prefs"), "a", {"text": "python"})
+    store.put(("users", "1", "docs"), "b", {"text": "java"})
+    store.put(("users", "2", "prefs"), "c", {"text": "python"})
+    store.put(("teams", "alpha"), "d", {"text": "python"})
+
+    by_prefix = store.list_namespaces(prefix=("users", "*"), max_depth=2)
+    by_suffix = store.list_namespaces(suffix=("prefs",))
+
+    assert by_prefix == [("users", "1"), ("users", "2")]
+    assert by_suffix == [("users", "1", "prefs"), ("users", "2", "prefs")]
+
+
+def test_ttl_expires_items_and_refreshes_on_read(store: OceanBaseStore) -> None:
+    store.put(("ttl",), "ephemeral", {"text": "python ttl"}, ttl=0.002)
+
+    time.sleep(0.03)
+    assert store.get(("ttl",), "ephemeral", refresh_ttl=True) is not None
+
+    time.sleep(0.03)
+    assert store.get(("ttl",), "ephemeral", refresh_ttl=False) is not None
+
+    time.sleep(0.12)
+    assert store.get(("ttl",), "ephemeral", refresh_ttl=False) is None
+
+
+@pytest.mark.asyncio
+async def test_async_store_methods_round_trip(store: OceanBaseStore) -> None:
+    await store.aput(("async",), "doc", {"text": "python async"})
+
+    item = await store.aget(("async",), "doc")
+    results = await store.asearch(("async",), query="python", limit=1)
+
+    assert item is not None
+    assert item.key == "doc"
+    assert [result.key for result in results] == ["doc"]
+
+
+@pytest.mark.asyncio
+async def test_abatch_offloads_sync_batch_work(store: OceanBaseStore) -> None:
+    calls: list[tuple[object, tuple[object, ...]]] = []
+
+    async def fake_to_thread(func: object, /, *args: object, **kwargs: object) -> object:
+        calls.append((func, args))
+        assert kwargs == {}
+        return "sentinel"
+
+    with patch("langchain_oceanbase.store.asyncio.to_thread", side_effect=fake_to_thread):
+        result = await store.abatch([])
+
+    assert result == "sentinel"
+    assert len(calls) == 1
+    func, args = calls[0]
+    assert getattr(func, "__self__", None) is store
+    assert getattr(func, "__func__", None) is OceanBaseStore.batch
+    assert args == ([],)

--- a/tests/unit_tests/test_store.py
+++ b/tests/unit_tests/test_store.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 from langchain_core.embeddings import Embeddings
 from sqlalchemy import MetaData, create_engine
+from sqlalchemy.pool import StaticPool
 
 from langchain_oceanbase.store import OceanBaseStore
 
@@ -29,14 +30,18 @@ class DummyEmbeddings(Embeddings):
         return [
             1.0 if "python" in lowered else 0.0,
             1.0 if "java" in lowered else 0.0,
-            float((len(lowered) % 7) + 1),
+            1.0 if "python" not in lowered and "java" not in lowered else 0.0,
         ]
 
 
 @pytest.fixture
 def store() -> OceanBaseStore:
     fake_client = SimpleNamespace(
-        engine=create_engine("sqlite:///:memory:"),
+        engine=create_engine(
+            "sqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        ),
         metadata_obj=MetaData(),
     )
     with patch("langchain_oceanbase.store.ObVecClient", return_value=fake_client):
@@ -126,15 +131,15 @@ def test_list_namespaces_supports_prefix_suffix_and_depth(store: OceanBaseStore)
 
 
 def test_ttl_expires_items_and_refreshes_on_read(store: OceanBaseStore) -> None:
-    store.put(("ttl",), "ephemeral", {"text": "python ttl"}, ttl=0.002)
+    store.put(("ttl",), "ephemeral", {"text": "ttl marker"}, ttl=0.005)
 
-    time.sleep(0.03)
+    time.sleep(0.05)
     assert store.get(("ttl",), "ephemeral", refresh_ttl=True) is not None
 
-    time.sleep(0.03)
+    time.sleep(0.05)
     assert store.get(("ttl",), "ephemeral", refresh_ttl=False) is not None
 
-    time.sleep(0.12)
+    time.sleep(0.35)
     assert store.get(("ttl",), "ephemeral", refresh_ttl=False) is None
 
 

--- a/tests/unit_tests/test_vectorstore_standard.py
+++ b/tests/unit_tests/test_vectorstore_standard.py
@@ -182,3 +182,26 @@ class TestOceanbaseVectorStoreUnit:
 
         with pytest.raises(ResourceClosedError, match="unexpected close"):
             vectorstore.similarity_search("query", k=1)
+
+    def test_hybrid_result_combiner_ignores_results_without_ids(self, vectorstore):
+        combined = vectorstore._combine_multi_modal_results(
+            [
+                ("vector", [{"document": "", "metadata": {}}]),
+                (
+                    "fulltext",
+                    [
+                        {
+                            "id": "doc-1",
+                            "document": "useful content",
+                            "metadata": {"topic": "AI"},
+                        }
+                    ],
+                ),
+            ],
+            k=2,
+        )
+
+        docs = vectorstore._convert_list_results_to_documents(combined)
+
+        assert [doc.id for doc in docs] == ["doc-1"]
+        assert docs[0].metadata == {"topic": "AI"}

--- a/tests/unit_tests/test_vectorstore_standard.py
+++ b/tests/unit_tests/test_vectorstore_standard.py
@@ -183,6 +183,30 @@ class TestOceanbaseVectorStoreUnit:
         with pytest.raises(ResourceClosedError, match="unexpected close"):
             vectorstore.similarity_search("query", k=1)
 
+    def test_advanced_hybrid_search_returns_empty_when_backend_returns_no_rows(
+        self, vectorstore, mock_client
+    ):
+        """Vector-only hybrid search should map empty backend results to []."""
+        vectorstore.embedding_function.embed_query.return_value = [1.0] * 384
+
+        class EmptyClosedResult:
+            def fetchall(self):
+                raise ResourceClosedError(
+                    "This result object does not return rows. It has been closed automatically."
+                )
+
+            def __iter__(self):
+                raise ResourceClosedError(
+                    "This result object does not return rows. It has been closed automatically."
+                )
+
+        mock_result = EmptyClosedResult()
+        mock_client.ann_search.return_value = mock_result
+
+        docs = vectorstore.advanced_hybrid_search(vector_query="query", k=1)
+
+        assert docs == []
+
     def test_hybrid_result_combiner_ignores_results_without_ids(self, vectorstore):
         combined = vectorstore._combine_multi_modal_results(
             [

--- a/tests/unit_tests/test_vectorstore_standard.py
+++ b/tests/unit_tests/test_vectorstore_standard.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 from unittest.mock import MagicMock, patch
 
@@ -261,3 +262,21 @@ class TestOceanbaseVectorStoreUnit:
 
         assert [doc.id for doc in docs] == ["doc-1", "doc-2"]
         assert [doc.metadata for doc in docs] == [{"topic": "AI"}, {"topic": "ML"}]
+
+    @pytest.mark.skipif(
+        importlib.util.find_spec("pyseekdb") is not None,
+        reason="pyseekdb is installed",
+    )
+    def test_default_embedding_requires_optional_dependency(self):
+        """Default embeddings should fail with an actionable optional-dependency message."""
+        with pytest.raises(ImportError, match="langchain-oceanbase\\[pyseekdb\\]"):
+            OceanbaseVectorStore(
+                connection_args={
+                    "host": "localhost",
+                    "port": "2881",
+                    "user": "root",
+                    "password": "",
+                    "db_name": "test",
+                },
+                table_name="test_table",
+            )

--- a/tests/unit_tests/test_vectorstore_standard.py
+++ b/tests/unit_tests/test_vectorstore_standard.py
@@ -205,3 +205,35 @@ class TestOceanbaseVectorStoreUnit:
 
         assert [doc.id for doc in docs] == ["doc-1"]
         assert docs[0].metadata == {"topic": "AI"}
+
+    def test_hybrid_result_combiner_reads_dotted_row_keys(self, vectorstore):
+        combined = vectorstore._combine_multi_modal_results(
+            [
+                (
+                    "vector",
+                    [
+                        {
+                            "test_table.id": "doc-1",
+                            "test_table.document": "useful content",
+                            "test_table.metadata": '{"topic": "AI"}',
+                        }
+                    ],
+                ),
+                (
+                    "sparse",
+                    [
+                        {
+                            "test_table.id": "doc-2",
+                            "test_table.document": "backup content",
+                            "test_table.metadata": '{"topic": "ML"}',
+                        }
+                    ],
+                ),
+            ],
+            k=2,
+        )
+
+        docs = vectorstore._convert_list_results_to_documents(combined)
+
+        assert [doc.id for doc in docs] == ["doc-1", "doc-2"]
+        assert [doc.metadata for doc in docs] == [{"topic": "AI"}, {"topic": "ML"}]


### PR DESCRIPTION
## What

- release `0.5.0` from the latest `develop` state, including LangGraph store support
- update release notes and examples to introduce store support and deprecate `chat_message_histories`
- include the embedded SeekDB vectorstore capacity-handling fix so the merged-`develop` CI regression does not carry into the release line

## Validation

- `./.venv/bin/pytest tests/unit_tests/test_backend_utils.py tests/unit_tests/test_vectorstore_standard.py -q`
- `python3 -m py_compile tests/integration_tests/_backend_utils.py tests/integration_tests/test_vectorstores.py tests/unit_tests/test_backend_utils.py`
- `git diff --check`

## Git-Flow Check

- [x] I targeted `main` only from a `release/*`, `hotfix/*`, or approved maintenance branch
- [x] I used a git-flow style branch name
