### PR TITLE
chore: split pyseekdb to extra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
           - name: embedded-seekdb
             artifact-suffix: embedded-seekdb-base
             db-type: embedded-seekdb
+            poetry-extra-args: -E pyseekdb
             port: ""
             user: ""
             image: ""
@@ -79,6 +80,7 @@ jobs:
           - name: oceanbase
             artifact-suffix: oceanbase-base
             db-type: oceanbase
+            poetry-extra-args: ""
             port: 2881
             user: root@test
             image: oceanbase/oceanbase-ce:4.3.5-lts
@@ -94,6 +96,7 @@ jobs:
           - name: seekdb
             artifact-suffix: seekdb-base
             db-type: seekdb
+            poetry-extra-args: ""
             port: 2882
             user: root
             image: oceanbase/seekdb
@@ -109,6 +112,7 @@ jobs:
           - name: mysql
             artifact-suffix: mysql-base
             db-type: mysql
+            poetry-extra-args: ""
             port: 3306
             user: root
             image: mysql:8.4
@@ -124,6 +128,7 @@ jobs:
           - name: embedded-seekdb, latest-checkpoint-stack
             artifact-suffix: embedded-seekdb-latest
             db-type: embedded-seekdb
+            poetry-extra-args: -E pyseekdb
             port: ""
             user: ""
             image: ""
@@ -139,6 +144,7 @@ jobs:
           - name: oceanbase, latest-checkpoint-stack
             artifact-suffix: oceanbase-latest
             db-type: oceanbase
+            poetry-extra-args: ""
             port: 2881
             user: root@test
             image: oceanbase/oceanbase-ce:4.3.5-lts
@@ -154,6 +160,7 @@ jobs:
           - name: seekdb, latest-checkpoint-stack
             artifact-suffix: seekdb-latest
             db-type: seekdb
+            poetry-extra-args: ""
             port: 2882
             user: root
             image: oceanbase/seekdb
@@ -169,6 +176,7 @@ jobs:
           - name: mysql, latest-checkpoint-stack
             artifact-suffix: mysql-latest
             db-type: mysql
+            poetry-extra-args: ""
             port: 3306
             user: root
             image: mysql:8.4
@@ -206,7 +214,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          poetry install --with test,test_integration --no-interaction
+          poetry install --with test,test_integration --no-interaction ${{ matrix.poetry-extra-args }}
 
       - name: Upgrade to latest supported LangChain and LangGraph stack
         if: matrix.upgrade-latest-stack
@@ -602,7 +610,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          poetry install --with test --no-interaction --no-root
+          poetry install --with test --no-interaction --no-root -E pyseekdb
 
       - name: Test embedding functionality
         run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -36,20 +36,9 @@ jobs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
-    - name: Install pyseekdb and dependencies first
-      run: |
-        pip install pyseekdb
-
     - name: Install dependencies
       run: |
-        set +e
-        poetry install --no-interaction --no-cache 2>&1 | tee /tmp/poetry_install.log || true
-        if grep -q "onnxruntime.*abi tags" /tmp/poetry_install.log; then
-          echo "Detected onnxruntime ABI issue, installing dependencies manually..."
-          poetry install --no-interaction --no-cache --no-deps || true
-          poetry run pip install -r <(poetry export --without-hashes --format=requirements.txt 2>/dev/null | grep -v "^onnxruntime" | grep -v "^pyseekdb" || echo "") || true
-        fi
-        set -e
+        poetry install --no-interaction --no-cache --no-root
 
     - name: Build package
       run: |

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ pip install -U langchain-oceanbase
 - Python >=3.11
 - langchain-core >=1.0.0
 - pyobvector >=0.2.0 (required for database client)
-- pyseekdb >=0.1.0 (required dependency; use **>=1.2** on supported platforms for **embedded SeekDB** and the `pylibseekdb` runtime)
+- `pyseekdb` extra (optional; install `langchain-oceanbase[pyseekdb]` for built-in embeddings and embedded SeekDB support)
 
 > **Tip**: The current version (0.4.0) supports `langchain-core >=1.0.0`. See [CHANGELOG.md](./CHANGELOG.md) for version history.
 
@@ -94,7 +94,13 @@ pip install -U langchain-oceanbase
 
 ### Built-in Embedding Dependencies
 
-For built-in embedding functionality (no API keys required), `pyseekdb` is automatically installed as an optional dependency. It provides:
+For built-in embedding functionality (no API keys required), install the optional `pyseekdb` extra:
+
+```bash
+pip install -U "langchain-oceanbase[pyseekdb]"
+```
+
+It provides:
 - Local ONNX-based embedding inference
 - Default embedding model: `all-MiniLM-L6-v2` (384 dimensions)
 - No external API calls needed

--- a/docs/embeddings.md
+++ b/docs/embeddings.md
@@ -7,10 +7,10 @@ This guide demonstrates how to use the built-in embedding functionality provided
 
 ## Installation
 
-The built-in embedding functionality requires the `pyseekdb` package, which uses ONNX runtime for local inference:
+The built-in embedding functionality requires the optional `pyseekdb` extra, which uses ONNX runtime for local inference:
 
 ```bash
-pip install -qU "langchain-oceanbase" "pyseekdb"
+pip install -qU "langchain-oceanbase[pyseekdb]"
 ```
 
 ## Method 1: Direct Use of DefaultEmbeddingFunction

--- a/docs/vectorstores.md
+++ b/docs/vectorstores.md
@@ -57,7 +57,7 @@ Instead of running an OceanBase server, you can use **embedded SeekDB** via [pyo
 **Install** (installs the embedded runtime `pylibseekdb` on supported platforms):
 
 ```text
-pip install -U "langchain-oceanbase" "pyobvector[pyseekdb]"
+pip install -U "langchain-oceanbase[pyseekdb]"
 ```
 
 If imports fail, upgrade `pyseekdb` so the platform wheel for `pylibseekdb` is installed, for example:

--- a/examples/embedded_seekdb_vectorstore.py
+++ b/examples/embedded_seekdb_vectorstore.py
@@ -7,7 +7,7 @@ Standalone example: ``langchain-oceanbase`` with latest ``pyobvector`` and **emb
 
 Install (virtualenv recommended)::
 
-    pip install -U langchain-oceanbase "pyobvector[pyseekdb]"
+    pip install -U "langchain-oceanbase[pyseekdb]"
 
 Embedded mode needs a recent ``pyseekdb`` that installs the ``pylibseekdb`` wheel. If imports fail::
 
@@ -32,7 +32,7 @@ def _require_embedded_runtime() -> None:
     except ImportError:
         print(
             "pylibseekdb (embedded SeekDB runtime) not found. Install with:\n"
-            '  pip install -U langchain-oceanbase "pyobvector[pyseekdb]"\n'
+            '  pip install -U "langchain-oceanbase[pyseekdb]"\n'
             "or:\n"
             '  pip install -U "pyseekdb>=1.2"',
             file=sys.stderr,

--- a/langchain_oceanbase/embedding_utils.py
+++ b/langchain_oceanbase/embedding_utils.py
@@ -28,21 +28,43 @@ Usage Examples:
     >>> query_embedding = embeddings.embed_query("Hello")
 """
 
-from __future__ import annotations
-
 import logging
+import platform
 from typing import List, Optional
 
 from langchain_core.embeddings import Embeddings
 
-try:
-    from pyseekdb import DefaultEmbeddingFunction
-except ImportError:
-    DefaultEmbeddingFunction = None  # type: ignore
-
 logger = logging.getLogger(__name__)
 
 __all__ = ["DefaultEmbeddingFunction", "DefaultEmbeddingFunctionAdapter"]
+
+DEFAULT_EMBEDDING_INSTALL_COMMAND = 'pip install -U "langchain-oceanbase[pyseekdb]"'
+
+
+try:
+    from pyseekdb import DefaultEmbeddingFunction
+except ImportError as exc:
+    DefaultEmbeddingFunction = None  # type: ignore[assignment]
+    _PYSEEKDB_IMPORT_ERROR = exc
+else:
+    _PYSEEKDB_IMPORT_ERROR = None
+
+
+def _raise_for_missing_pyseekdb() -> None:
+    message = (
+        "pyseekdb is not installed. "
+        "Install the optional embedding dependencies with: "
+        f"{DEFAULT_EMBEDDING_INSTALL_COMMAND}"
+    )
+    system = platform.system()
+    if system != "Linux":
+        message += (
+            f"\n\nNote: pyseekdb currently has the best support on Linux. "
+            f"Your system is {system}. "
+            "Consider using Linux (via Docker, WSL2, or a Linux VM) "
+            "or connecting to a remote OceanBase/SeekDB instance."
+        )
+    raise ImportError(message) from _PYSEEKDB_IMPORT_ERROR
 
 
 class DefaultEmbeddingFunctionAdapter(Embeddings):
@@ -60,7 +82,7 @@ class DefaultEmbeddingFunctionAdapter(Embeddings):
         self,
         model_name: str = "all-MiniLM-L6-v2",
         preferred_providers: Optional[List[str]] = None,
-    ):
+    ) -> None:
         """
         Initialize the adapter.
 
@@ -70,22 +92,7 @@ class DefaultEmbeddingFunctionAdapter(Embeddings):
         """
         super().__init__()
         if DefaultEmbeddingFunction is None:
-            import platform
-
-            system = platform.system()
-            error_msg = (
-                "pyseekdb is not installed or cannot be imported. "
-                "Please install it with: pip install pyseekdb"
-            )
-            if system != "Linux":
-                error_msg += (
-                    f"\n\nNote: pyseekdb currently only supports Linux platforms. "
-                    f"Your system is {system}. "
-                    "Consider using Linux (via Docker, WSL2, or a Linux VM) "
-                    "or connecting to a remote OceanBase/SeekDB instance."
-                )
-            raise ImportError(error_msg)
-
+            _raise_for_missing_pyseekdb()
         self._pyseekdb_embedding_function = DefaultEmbeddingFunction(
             model_name=model_name,
             preferred_providers=preferred_providers,

--- a/poetry.lock
+++ b/poetry.lock
@@ -551,9 +551,10 @@ files = [
 name = "click"
 version = "8.3.1"
 description = "Composable command line interface toolkit"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"},
     {file = "click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a"},
@@ -591,15 +592,16 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\"", test = "sys_platform == \"win32\""}
+markers = {main = "extra == \"pyseekdb\" and platform_system == \"Windows\"", dev = "sys_platform == \"win32\"", test = "sys_platform == \"win32\""}
 
 [[package]]
 name = "coloredlogs"
 version = "15.0.1"
 description = "Colored terminal output for Python's logging module"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934"},
     {file = "coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0"},
@@ -949,14 +951,16 @@ files = [
     {file = "filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70"},
     {file = "filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694"},
 ]
+markers = {main = "extra == \"pyseekdb\""}
 
 [[package]]
 name = "flatbuffers"
 version = "25.9.23"
 description = "The FlatBuffers serialization format for Python"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "flatbuffers-25.9.23-py2.py3-none-any.whl", hash = "sha256:255538574d6cb6d0a79a17ec8bc0d30985913b87513a01cce8bcdb6b4c44d0e2"},
     {file = "flatbuffers-25.9.23.tar.gz", hash = "sha256:676f9fa62750bb50cf531b42a0a2a118ad8f7f797a511eda12881c016f093b12"},
@@ -1106,9 +1110,10 @@ files = [
 name = "fsspec"
 version = "2025.12.0"
 description = "File-system specification"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "fsspec-2025.12.0-py3-none-any.whl", hash = "sha256:8bf1fe301b7d8acfa6e8571e3b1c3d158f909666642431cc78a1b7b4dbc5ec5b"},
     {file = "fsspec-2025.12.0.tar.gz", hash = "sha256:c505de011584597b1060ff778bb664c1bc022e87921b0e4f10cc9c44f9635973"},
@@ -1221,10 +1226,10 @@ files = [
 name = "hf-xet"
 version = "1.2.0"
 description = "Fast transfer of large files with the Hugging Face Hub."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\""
+markers = "extra == \"pyseekdb\" and (platform_machine == \"x86_64\" or platform_machine == \"amd64\" or platform_machine == \"AMD64\" or platform_machine == \"arm64\" or platform_machine == \"aarch64\")"
 files = [
     {file = "hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649"},
     {file = "hf_xet-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b70218dd548e9840224df5638fdc94bd033552963cfa97f9170829381179c813"},
@@ -1316,9 +1321,10 @@ files = [
 name = "huggingface-hub"
 version = "1.2.2"
 description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
-optional = false
+optional = true
 python-versions = ">=3.9.0"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "huggingface_hub-1.2.2-py3-none-any.whl", hash = "sha256:0f55d7d22058fbf8b29d8095aeee80a7b695aa764f906a21e886c1f87223718f"},
     {file = "huggingface_hub-1.2.2.tar.gz", hash = "sha256:b5b97bd37f4fe5b898a467373044649c94ee32006c032ce8fb835abe9d92ea28"},
@@ -1352,9 +1358,10 @@ typing = ["types-PyYAML", "types-simplejson", "types-toml", "types-tqdm", "types
 name = "humanfriendly"
 version = "10.0"
 description = "Human friendly output for text interfaces using Python"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477"},
     {file = "humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc"},
@@ -2007,9 +2014,10 @@ files = [
 name = "mpmath"
 version = "1.3.0"
 description = "Python library for arbitrary-precision floating-point arithmetic"
-optional = false
+optional = true
 python-versions = "*"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c"},
     {file = "mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f"},
@@ -2369,9 +2377,10 @@ files = [
 name = "onnxruntime"
 version = "1.23.2"
 description = "ONNX Runtime is a runtime accelerator for Machine Learning models"
-optional = false
+optional = true
 python-versions = ">=3.10"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3"},
     {file = "onnxruntime-1.23.2-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:b28740f4ecef1738ea8f807461dd541b8287d5650b5be33bca7b474e3cbd1f36"},
@@ -2826,9 +2835,10 @@ files = [
 name = "protobuf"
 version = "6.33.2"
 description = ""
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "protobuf-6.33.2-cp310-abi3-win32.whl", hash = "sha256:87eb388bd2d0f78febd8f4c8779c79247b26a5befad525008e49a6955787ff3d"},
     {file = "protobuf-6.33.2-cp310-abi3-win_amd64.whl", hash = "sha256:fc2a0e8b05b180e5fc0dd1559fe8ebdae21a27e81ac77728fb6c42b12c7419b4"},
@@ -3126,10 +3136,10 @@ windows-terminal = ["colorama (>=0.4.6)"]
 name = "pylibseekdb"
 version = "1.1.0"
 description = "An AI-Native Search Database. Unifies vector, text, structured and semi-structured data in a single engine, enabling hybrid search and in-database AI workflows."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "sys_platform == \"linux\" or sys_platform == \"darwin\" and platform_machine == \"arm64\""
+markers = "(sys_platform == \"linux\" or sys_platform == \"darwin\" and platform_machine == \"arm64\") and extra == \"pyseekdb\""
 files = [
     {file = "pylibseekdb-1.1.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:beaed68943cb59d41c968086eff4efd018291ae5faa66e6b273794a28574d5cb"},
     {file = "pylibseekdb-1.1.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:9902f008118b23a7c74747b013c382342ae245c3ea34b498e831319f81de02e9"},
@@ -3184,6 +3194,7 @@ aiomysql = ">=0.3.2"
 numpy = ">=1.17.0"
 pydantic = ">=2.7.0,<3"
 pymysql = ">=1.1.1"
+pyseekdb = {version = ">=0.1.0", optional = true, markers = "python_version >= \"3.11\" and extra == \"pyseekdb\""}
 sqlalchemy = ">=1.4,<=3"
 sqlglot = ">=26.0.1"
 
@@ -3194,10 +3205,10 @@ pyseekdb = ["pyseekdb (>=0.1.0) ; python_version >= \"3.11\""]
 name = "pyreadline3"
 version = "3.5.4"
 description = "A python implementation of GNU readline."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
-markers = "sys_platform == \"win32\""
+markers = "extra == \"pyseekdb\" and sys_platform == \"win32\""
 files = [
     {file = "pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6"},
     {file = "pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7"},
@@ -3210,9 +3221,10 @@ dev = ["build", "flake8", "mypy", "pytest", "twine"]
 name = "pyseekdb"
 version = "1.2.0.post2"
 description = "A unified Python client for seekdb that supports embedded, server, and OceanBase."
-optional = false
+optional = true
 python-versions = "<4,>=3.11"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "pyseekdb-1.2.0.post2-py3-none-any.whl", hash = "sha256:2ace81ac64777ec2c615faf4a384f42922ac6b4648a136a010e90e7a1ed81c7a"},
 ]
@@ -3725,9 +3737,10 @@ files = [
 name = "shellingham"
 version = "1.5.4"
 description = "Tool to Detect Surrounding Shell"
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
     {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
@@ -3876,9 +3889,10 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 name = "sympy"
 version = "1.14.0"
 description = "Computer algebra system (CAS) in Python"
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5"},
     {file = "sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517"},
@@ -3925,9 +3939,10 @@ test = ["pytest", "tornado (>=4.5)", "typeguard"]
 name = "tokenizers"
 version = "0.22.1"
 description = ""
-optional = false
+optional = true
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "tokenizers-0.22.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:59fdb013df17455e5f950b4b834a7b3ee2e0271e6378ccb33aa74d178b513c73"},
     {file = "tokenizers-0.22.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:8d4e484f7b0827021ac5f9f71d4794aaef62b979ab7608593da22b1d2e3c4edc"},
@@ -3980,9 +3995,10 @@ files = [
 name = "tqdm"
 version = "4.67.1"
 description = "Fast, Extensible Progress Meter"
-optional = false
+optional = true
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2"},
     {file = "tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"},
@@ -4018,9 +4034,10 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,
 name = "typer-slim"
 version = "0.20.0"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
-optional = false
+optional = true
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "extra == \"pyseekdb\""
 files = [
     {file = "typer_slim-0.20.0-py3-none-any.whl", hash = "sha256:f42a9b7571a12b97dddf364745d29f12221865acef7a2680065f9bb29c7dc89d"},
     {file = "typer_slim-0.20.0.tar.gz", hash = "sha256:9fc6607b3c6c20f5c33ea9590cbeb17848667c51feee27d9e314a579ab07d1a3"},
@@ -4770,7 +4787,10 @@ files = [
 [package.extras]
 cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and python_version < \"3.14\"", "cffi (>=2.0.0b0) ; platform_python_implementation != \"PyPy\" and python_version >= \"3.14\""]
 
+[extras]
+pyseekdb = ["pylibseekdb", "pyseekdb"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "b30d51e82f6d019927365b1eb557c411268775e967dd3b87e7cc69bdc17bae25"
+content-hash = "7b3f8a21976252aa535291e2ce941bb9d09d661668c9899b3887960b48a46d7a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,18 @@ langgraph = ">=0.6.11,<2.0.0"
 langgraph-checkpoint = ">=3.0.1,<5.0.0"
 # >=1.2: unified SeekDB client. Constrain pylibseekdb so the lock resolves to 1.1+ (manylinux + macOS arm64 wheels);
 # 1.0.0.post1 is Linux-wheel-only metadata and breaks Poetry on macOS arm64 / some CI installers.
-pyseekdb = ">=1.2.0.post1,<3"
+pyseekdb = { version = ">=1.2.0.post1,<3", optional = true }
 # Cap <1.2: pylibseekdb 1.2+ wheels are manylinux-only; 1.1.x includes macOS arm64 for local dev + Linux for CI
-pylibseekdb = { version = ">=1.1.0,<1.2", markers = "sys_platform == 'linux' or (sys_platform == 'darwin' and platform_machine == 'arm64')" }
-pyobvector = ">=0.2.25"
+pylibseekdb = { version = ">=1.1.0,<1.2", optional = true, markers = "sys_platform == 'linux' or (sys_platform == 'darwin' and platform_machine == 'arm64')" }
+pyobvector = [
+    { version = ">=0.2.25" },
+    { version = ">=0.2.25", extras = ["pyseekdb"], markers = "extra == 'pyseekdb'" },
+]
 # Pin to safe version for security (CVE-2025-69228 etc.); direct dep so Dependabot can update
 aiohttp = ">=3.13.3"
+
+[tool.poetry.extras]
+pyseekdb = ["pyseekdb", "pylibseekdb"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "T201"]

--- a/tests/integration_tests/test_embedding_vectorization.py
+++ b/tests/integration_tests/test_embedding_vectorization.py
@@ -5,9 +5,8 @@ including DefaultEmbeddingFunction and DefaultEmbeddingFunctionAdapter.
 These tests verify that embeddings can be generated correctly without requiring
 database connections.
 
-Note: pyseekdb is a required dependency (defined in pyproject.toml), so these
-tests should always run in CI environments. If pyseekdb is not available,
-the tests will fail, which helps identify dependency issues early.
+Note: pyseekdb is an optional dependency. These tests run only when the
+pyseekdb extra is installed.
 """
 
 import pytest

--- a/tests/integration_tests/test_hybrid_search.py
+++ b/tests/integration_tests/test_hybrid_search.py
@@ -1,13 +1,13 @@
-from __future__ import annotations
-
 """Tests for OceanBase Vector Store hybrid search capabilities."""
+
+from __future__ import annotations
 
 import time
 
 import pytest
 from langchain_core.documents import Document
+from langchain_core.embeddings import FakeEmbeddings
 
-from langchain_oceanbase.embedding_utils import DefaultEmbeddingFunctionAdapter
 from langchain_oceanbase.exceptions import (
     OceanBaseConfigurationError,
     OceanBaseVectorDimensionError,
@@ -22,7 +22,7 @@ class TestHybridSearch:
     @pytest.fixture
     def embeddings(self):
         """Standard embeddings for testing."""
-        return DefaultEmbeddingFunctionAdapter()
+        return FakeEmbeddings(size=384)
 
     @pytest.fixture
     def hybrid_store_factory(

--- a/tests/integration_tests/test_vectorstores.py
+++ b/tests/integration_tests/test_vectorstores.py
@@ -4,12 +4,12 @@ from typing import Generator
 
 import pytest
 from langchain_core.documents import Document
+from langchain_core.embeddings import FakeEmbeddings
 from langchain_core.vectorstores import VectorStore
 from langchain_tests.integration_tests import (
     VectorStoreIntegrationTests,
 )
 
-from langchain_oceanbase.embedding_utils import DefaultEmbeddingFunctionAdapter
 from langchain_oceanbase.vectorstores import OceanbaseVectorStore
 from tests.integration_tests._backend_utils import (
     skip_embedded_seekdb_capacity_error,
@@ -40,8 +40,7 @@ def vectorstore_factory(
     ) -> OceanbaseVectorStore:
         try:
             store = OceanbaseVectorStore(
-                embedding_function=embedding_function
-                or DefaultEmbeddingFunctionAdapter(),
+                embedding_function=embedding_function or FakeEmbeddings(size=384),
                 table_name=table_name or unique_table_name("integration_test"),
                 connection_args=integration_connection_args,
                 vidx_metric_type=vidx_metric_type,
@@ -125,8 +124,7 @@ class TestOceanbaseVectorStoreIntegration:
         ids = vectorstore.add_documents(documents)
         assert len(ids) == 3
 
-        # Test that we can retrieve all documents by searching with empty string
-        # This should return all documents since DefaultEmbeddingFunctionAdapter generates consistent embeddings
+        # Test that we can retrieve all documents by searching with empty string.
         all_results = vectorstore.similarity_search("", k=10)
         assert len(all_results) >= 3
 

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -144,12 +144,11 @@ def test_basic_functionality() -> bool:
 
     try:
         from langchain_core.documents import Document
+        from langchain_core.embeddings import FakeEmbeddings
 
-        from langchain_oceanbase.embedding_utils import DefaultEmbeddingFunctionAdapter
         from langchain_oceanbase.vectorstores import OceanbaseVectorStore
 
-        # Create embeddings using DefaultEmbeddingFunctionAdapter
-        embeddings = DefaultEmbeddingFunctionAdapter()
+        embeddings = FakeEmbeddings(size=384)
 
         connection_args = _ci_connection_args()
 
@@ -238,11 +237,11 @@ def test_metric_types() -> bool:
 
     try:
         from langchain_core.documents import Document
+        from langchain_core.embeddings import FakeEmbeddings
 
-        from langchain_oceanbase.embedding_utils import DefaultEmbeddingFunctionAdapter
         from langchain_oceanbase.vectorstores import OceanbaseVectorStore
 
-        embeddings = DefaultEmbeddingFunctionAdapter()
+        embeddings = FakeEmbeddings(size=384)
 
         connection_args = _ci_connection_args()
 
@@ -290,10 +289,11 @@ def test_from_texts() -> bool:
     print("\nTesting from_texts method...")
 
     try:
-        from langchain_oceanbase.embedding_utils import DefaultEmbeddingFunctionAdapter
+        from langchain_core.embeddings import FakeEmbeddings
+
         from langchain_oceanbase.vectorstores import OceanbaseVectorStore
 
-        embeddings = DefaultEmbeddingFunctionAdapter()
+        embeddings = FakeEmbeddings(size=384)
 
         connection_args = _ci_connection_args()
 

--- a/tests/unit_tests/test_embedding_utils.py
+++ b/tests/unit_tests/test_embedding_utils.py
@@ -35,6 +35,23 @@ else:
     DefaultEmbeddingFunctionAdapter = None
 
 
+def test_embedding_module_imports_without_pyseekdb() -> None:
+    """The module should stay importable even when the optional extra is absent."""
+    assert embedding_utils_module is not None
+    if PYSEEKDB_AVAILABLE:
+        assert embedding_utils_module.DefaultEmbeddingFunction is not None
+    else:
+        assert embedding_utils_module.DefaultEmbeddingFunction is None
+
+
+@pytest.mark.skipif(PYSEEKDB_AVAILABLE, reason="pyseekdb is installed")
+def test_adapter_raises_clear_error_without_pyseekdb() -> None:
+    """Missing optional dependencies should fail with an actionable message."""
+    assert embedding_utils_module is not None
+    with pytest.raises(ImportError, match="langchain-oceanbase\\[pyseekdb\\]"):
+        embedding_utils_module.DefaultEmbeddingFunctionAdapter()
+
+
 @pytest.mark.skipif(
     PySeekDBDefaultEmbeddingFunction is None or DefaultEmbeddingFunction is None,
     reason="pyseekdb is not installed",
@@ -250,12 +267,13 @@ class TestDefaultEmbeddingFunctionAdapterErrorHandling:
         reason="pyseekdb is not installed or module cannot be imported, cannot test error handling",
     )
     def test_adapter_import_error_when_default_is_none(self):
-        """Test ImportError when DefaultEmbeddingFunction is None."""
+        """Test ImportError when pyseekdb is unavailable."""
         import unittest.mock
 
-        # Use mock instead of reload because reload will re-import from pyseekdb
         with unittest.mock.patch.object(
-            embedding_utils_module, "DefaultEmbeddingFunction", None
+            embedding_utils_module,
+            "DefaultEmbeddingFunction",
+            None,
         ):
             with pytest.raises(ImportError, match="pyseekdb is not installed"):
                 embedding_utils_module.DefaultEmbeddingFunctionAdapter()

--- a/tests/unit_tests/test_vectorstore_standard.py
+++ b/tests/unit_tests/test_vectorstore_standard.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 from unittest.mock import MagicMock, patch
 
@@ -261,3 +262,21 @@ class TestOceanbaseVectorStoreUnit:
 
         assert [doc.id for doc in docs] == ["doc-1", "doc-2"]
         assert [doc.metadata for doc in docs] == [{"topic": "AI"}, {"topic": "ML"}]
+
+    @pytest.mark.skipif(
+        importlib.util.find_spec("pyseekdb") is not None,
+        reason="pyseekdb is installed",
+    )
+    def test_default_embedding_requires_optional_dependency(self):
+        """Default embeddings should fail with an actionable optional-dependency message."""
+        with pytest.raises(ImportError, match="langchain-oceanbase\\[pyseekdb\\]"):
+            OceanbaseVectorStore(
+                connection_args={
+                    "host": "localhost",
+                    "port": "2881",
+                    "user": "root",
+                    "password": "",
+                    "db_name": "test",
+                },
+                table_name="test_table",
+            )


### PR DESCRIPTION
## Summary

Supersedes #122

- problem: pyseekdb and pylibseekdb is so big, and will intro too many useless deps for other users
- solution: just mark pyseekdb as an extra
- validation:

## Git-Flow Check

- [x] I targeted `develop` for regular work (`feature/*`, `bugfix/*`, `chore/*`, `docs/*`, `refactor/*`, `test/*`)
- [ ] I targeted `main` only from a `release/*`, `hotfix/*`, or approved maintenance branch
- [ ] I used a git-flow style branch name
