### PR TITLE
feat: support embedded SeekDB mode in checkpointer and store

### DIFF
--- a/langchain_oceanbase/checkpointer.py
+++ b/langchain_oceanbase/checkpointer.py
@@ -209,6 +209,9 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
                 - user: Database username (default: "root@test")
                 - password: Database password (default: "")
                 - db_name: Database name (default: "test")
+                - path: Embedded SeekDB data directory. When set, uses
+                  in-process SeekDB instead of a remote connection.
+                  Requires ``pip install langchain-oceanbase[pyseekdb]``.
             serde: Optional serializer for encoding/decoding checkpoints.
             **kwargs: Additional arguments passed to ObVecClient.
         """
@@ -231,20 +234,28 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         Raises:
             OceanBaseConnectionError: If connection to OceanBase fails.
         """
-        host = self.connection_args.get("host", "localhost")
-        port = self.connection_args.get("port", "2881")
-        user = self.connection_args.get("user", "root@test")
-        password = self.connection_args.get("password", "")
+        path = self.connection_args.get("path")
         db_name = self.connection_args.get("db_name", "test")
 
         try:
-            self.obvector: ObVecClient = ObVecClient(
-                uri=f"{host}:{port}",
-                user=user,
-                password=password,
-                db_name=db_name,
-                **kwargs,
-            )
+            if path is not None:
+                self.obvector: ObVecClient = ObVecClient(
+                    path=path,
+                    db_name=db_name,
+                    **kwargs,
+                )
+            else:
+                host = self.connection_args.get("host", "localhost")
+                port = self.connection_args.get("port", "2881")
+                user = self.connection_args.get("user", "root@test")
+                password = self.connection_args.get("password", "")
+                self.obvector = ObVecClient(
+                    uri=f"{host}:{port}",
+                    user=user,
+                    password=password,
+                    db_name=db_name,
+                    **kwargs,
+                )
         except Exception as e:
             error_msg = str(e).lower()
             if (
@@ -254,8 +265,8 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
             ):
                 raise OceanBaseConnectionError(
                     f"Failed to connect to OceanBase: {e}",
-                    host=host,
-                    port=port,
+                    host=self.connection_args.get("host", "localhost"),
+                    port=self.connection_args.get("port", "2881"),
                 ) from e
             # Re-raise other exceptions as-is
             logger.error(f"Failed to create OceanBase client: {e}")

--- a/langchain_oceanbase/store.py
+++ b/langchain_oceanbase/store.py
@@ -72,6 +72,23 @@ class OceanBaseStore(BaseStore):
         table_name: str = "langgraph_store_items",
         **kwargs: Any,
     ) -> None:
+        """Initialize the OceanBase store.
+
+        Args:
+            connection_args: Connection parameters. Should include:
+                - host: OceanBase server host (default: "localhost")
+                - port: OceanBase server port (default: "2881")
+                - user: Database username (default: "root@test")
+                - password: Database password (default: "")
+                - db_name: Database name (default: "test")
+                - path: Embedded SeekDB data directory. When set, uses
+                  in-process SeekDB instead of a remote connection.
+                  Requires ``pip install langchain-oceanbase[pyseekdb]``.
+            index: Optional index configuration for semantic search.
+            ttl_config: Optional TTL configuration for item expiration.
+            table_name: Name of the store table (default: "langgraph_store_items").
+            **kwargs: Additional arguments passed to ObVecClient.
+        """
         self.connection_args = (
             connection_args
             if connection_args is not None

--- a/langchain_oceanbase/store.py
+++ b/langchain_oceanbase/store.py
@@ -133,20 +133,28 @@ class OceanBaseStore(BaseStore):
             return results
 
     def _create_client(self, **kwargs: Any) -> None:
-        host = self.connection_args.get("host", "localhost")
-        port = self.connection_args.get("port", "2881")
-        user = self.connection_args.get("user", "root@test")
-        password = self.connection_args.get("password", "")
+        path = self.connection_args.get("path")
         db_name = self.connection_args.get("db_name", "test")
 
         try:
-            self.obvector: ObVecClient = ObVecClient(
-                uri=f"{host}:{port}",
-                user=user,
-                password=password,
-                db_name=db_name,
-                **kwargs,
-            )
+            if path is not None:
+                self.obvector: ObVecClient = ObVecClient(
+                    path=path,
+                    db_name=db_name,
+                    **kwargs,
+                )
+            else:
+                host = self.connection_args.get("host", "localhost")
+                port = self.connection_args.get("port", "2881")
+                user = self.connection_args.get("user", "root@test")
+                password = self.connection_args.get("password", "")
+                self.obvector = ObVecClient(
+                    uri=f"{host}:{port}",
+                    user=user,
+                    password=password,
+                    db_name=db_name,
+                    **kwargs,
+                )
         except Exception as exc:
             error_msg = str(exc).lower()
             if (
@@ -156,8 +164,8 @@ class OceanBaseStore(BaseStore):
             ):
                 raise OceanBaseConnectionError(
                     f"Failed to connect to OceanBase: {exc}",
-                    host=host,
-                    port=port,
+                    host=self.connection_args.get("host", "localhost"),
+                    port=self.connection_args.get("port", "2881"),
                 ) from exc
             raise
 

--- a/tests/integration_tests/_backend_utils.py
+++ b/tests/integration_tests/_backend_utils.py
@@ -68,8 +68,10 @@ def unique_table_name(prefix: str) -> str:
 
 def is_embedded_seekdb_capacity_error(exc: Exception) -> bool:
     message = str(exc)
-    return "execute sql failed 5703 Add index failed" in message or (
-        "execute sql failed 4184 Server out of disk space" in message
+    return (
+        "execute sql failed 5703 Add index failed" in message
+        or "execute sql failed 4184 Server out of disk space" in message
+        or "execute sql failed 4029 Schema error" in message
     )
 
 

--- a/tests/unit_tests/test_checkpointer_embed_mode.py
+++ b/tests/unit_tests/test_checkpointer_embed_mode.py
@@ -1,0 +1,133 @@
+"""Unit tests for embed-mode (path-based) constructor routing."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langchain_oceanbase.checkpointer import (
+    OceanBaseCheckpointSaver,
+    OceanBaseConnectionError,
+)
+
+
+@patch("langchain_oceanbase.checkpointer.ObVecClient")
+def test_path_in_connection_args_uses_embed_mode(mock_client_cls: MagicMock) -> None:
+    """When connection_args contains 'path', ObVecClient is created with path= kwarg."""
+    OceanBaseCheckpointSaver(connection_args={"path": "/tmp/seekdb", "db_name": "mydb"})
+
+    mock_client_cls.assert_called_once_with(path="/tmp/seekdb", db_name="mydb")
+
+
+@patch("langchain_oceanbase.checkpointer.ObVecClient")
+def test_embed_mode_omits_uri_user_password(mock_client_cls: MagicMock) -> None:
+    """Embed-mode constructor must not pass uri, user, or password to ObVecClient."""
+    OceanBaseCheckpointSaver(
+        connection_args={"path": "/data/seekdb", "host": "ignored", "user": "ignored"}
+    )
+
+    assert mock_client_cls.call_args.args == ()
+    call_kwargs = mock_client_cls.call_args.kwargs
+    assert "uri" not in call_kwargs
+    assert "user" not in call_kwargs
+    assert "password" not in call_kwargs
+    assert call_kwargs["path"] == "/data/seekdb"
+
+
+@patch("langchain_oceanbase.checkpointer.ObVecClient")
+def test_no_path_uses_remote_mode(mock_client_cls: MagicMock) -> None:
+    """Without 'path', ObVecClient is created with uri/user/password."""
+    OceanBaseCheckpointSaver(
+        connection_args={
+            "host": "10.0.0.1",
+            "port": "3306",
+            "user": "admin",
+            "password": "secret",
+            "db_name": "prod",
+        }
+    )
+
+    mock_client_cls.assert_called_once_with(
+        uri="10.0.0.1:3306",
+        user="admin",
+        password="secret",
+        db_name="prod",
+    )
+
+
+@patch("langchain_oceanbase.checkpointer.ObVecClient")
+def test_remote_mode_defaults(mock_client_cls: MagicMock) -> None:
+    """Remote mode should apply defaults for missing host/port/user/password."""
+    OceanBaseCheckpointSaver(connection_args={})
+
+    mock_client_cls.assert_called_once_with(
+        uri="localhost:2881",
+        user="root@test",
+        password="",
+        db_name="test",
+    )
+
+
+@patch("langchain_oceanbase.checkpointer.ObVecClient")
+def test_embed_mode_forwards_extra_kwargs(mock_client_cls: MagicMock) -> None:
+    """Extra kwargs from the constructor should forward to ObVecClient in embed mode."""
+    OceanBaseCheckpointSaver(
+        connection_args={"path": "/tmp/seekdb"},
+        timeout=30,
+    )
+
+    call_kwargs = mock_client_cls.call_args.kwargs
+    assert call_kwargs["timeout"] == 30
+    assert call_kwargs["path"] == "/tmp/seekdb"
+
+
+@patch("langchain_oceanbase.checkpointer.ObVecClient")
+def test_remote_mode_forwards_extra_kwargs(mock_client_cls: MagicMock) -> None:
+    """Extra kwargs from the constructor should forward to ObVecClient in remote mode."""
+    OceanBaseCheckpointSaver(
+        connection_args={"host": "db.local"},
+        pool_size=5,
+    )
+
+    call_kwargs = mock_client_cls.call_args.kwargs
+    assert call_kwargs["pool_size"] == 5
+
+
+@patch("langchain_oceanbase.checkpointer.ObVecClient")
+def test_embed_mode_connection_error_still_reports_host_port(
+    mock_client_cls: MagicMock,
+) -> None:
+    """A connection-related error in embed mode should not crash on missing host/port."""
+    mock_client_cls.side_effect = RuntimeError("connection refused by seekdb")
+
+    with pytest.raises(OceanBaseConnectionError) as exc_info:
+        OceanBaseCheckpointSaver(connection_args={"path": "/bad/path"})
+
+    assert exc_info.value.host == "localhost"
+    assert exc_info.value.port == "2881"
+
+
+@patch("langchain_oceanbase.checkpointer.ObVecClient")
+def test_embed_mode_non_connection_error_reraises(
+    mock_client_cls: MagicMock,
+) -> None:
+    """Non-connection errors in embed mode should re-raise as-is."""
+    mock_client_cls.side_effect = ValueError("invalid db_name")
+
+    with pytest.raises(ValueError, match="invalid db_name"):
+        OceanBaseCheckpointSaver(connection_args={"path": "/tmp/seekdb"})
+
+
+@patch("langchain_oceanbase.checkpointer.ObVecClient")
+def test_path_none_in_connection_args_uses_remote_mode(
+    mock_client_cls: MagicMock,
+) -> None:
+    """Explicit path=None in connection_args should use remote mode."""
+    OceanBaseCheckpointSaver(
+        connection_args={"path": None, "host": "myhost", "port": "1234"}
+    )
+
+    call_kwargs = mock_client_cls.call_args.kwargs
+    assert "path" not in call_kwargs
+    assert call_kwargs["uri"] == "myhost:1234"

--- a/tests/unit_tests/test_store_embed_mode.py
+++ b/tests/unit_tests/test_store_embed_mode.py
@@ -1,0 +1,131 @@
+"""Unit tests for OceanBaseStore embed-mode (path-based) constructor routing."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langchain_oceanbase.exceptions import OceanBaseConnectionError
+from langchain_oceanbase.store import OceanBaseStore
+
+
+@patch("langchain_oceanbase.store.ObVecClient")
+def test_path_in_connection_args_uses_embed_mode(mock_client_cls: MagicMock) -> None:
+    """When connection_args contains 'path', ObVecClient is created with path= kwarg."""
+    OceanBaseStore(connection_args={"path": "/tmp/seekdb", "db_name": "mydb"})
+
+    mock_client_cls.assert_called_once_with(path="/tmp/seekdb", db_name="mydb")
+
+
+@patch("langchain_oceanbase.store.ObVecClient")
+def test_embed_mode_omits_uri_user_password(mock_client_cls: MagicMock) -> None:
+    """Embed-mode constructor must not pass uri, user, or password to ObVecClient."""
+    OceanBaseStore(
+        connection_args={"path": "/data/seekdb", "host": "ignored", "user": "ignored"}
+    )
+
+    assert mock_client_cls.call_args.args == ()
+    call_kwargs = mock_client_cls.call_args.kwargs
+    assert "uri" not in call_kwargs
+    assert "user" not in call_kwargs
+    assert "password" not in call_kwargs
+    assert call_kwargs["path"] == "/data/seekdb"
+
+
+@patch("langchain_oceanbase.store.ObVecClient")
+def test_no_path_uses_remote_mode(mock_client_cls: MagicMock) -> None:
+    """Without 'path', ObVecClient is created with uri/user/password."""
+    OceanBaseStore(
+        connection_args={
+            "host": "10.0.0.1",
+            "port": "3306",
+            "user": "admin",
+            "password": "secret",
+            "db_name": "prod",
+        }
+    )
+
+    mock_client_cls.assert_called_once_with(
+        uri="10.0.0.1:3306",
+        user="admin",
+        password="secret",
+        db_name="prod",
+    )
+
+
+@patch("langchain_oceanbase.store.ObVecClient")
+def test_remote_mode_defaults(mock_client_cls: MagicMock) -> None:
+    """Remote mode should apply defaults for missing host/port/user/password."""
+    OceanBaseStore(connection_args={})
+
+    mock_client_cls.assert_called_once_with(
+        uri="localhost:2881",
+        user="root@test",
+        password="",
+        db_name="test",
+    )
+
+
+@patch("langchain_oceanbase.store.ObVecClient")
+def test_embed_mode_forwards_extra_kwargs(mock_client_cls: MagicMock) -> None:
+    """Extra kwargs from the constructor should forward to ObVecClient in embed mode."""
+    OceanBaseStore(
+        connection_args={"path": "/tmp/seekdb"},
+        timeout=30,
+    )
+
+    call_kwargs = mock_client_cls.call_args.kwargs
+    assert call_kwargs["timeout"] == 30
+    assert call_kwargs["path"] == "/tmp/seekdb"
+
+
+@patch("langchain_oceanbase.store.ObVecClient")
+def test_remote_mode_forwards_extra_kwargs(mock_client_cls: MagicMock) -> None:
+    """Extra kwargs from the constructor should forward to ObVecClient in remote mode."""
+    OceanBaseStore(
+        connection_args={"host": "db.local"},
+        pool_size=5,
+    )
+
+    call_kwargs = mock_client_cls.call_args.kwargs
+    assert call_kwargs["pool_size"] == 5
+
+
+@patch("langchain_oceanbase.store.ObVecClient")
+def test_embed_mode_connection_error_reports_defaults(
+    mock_client_cls: MagicMock,
+) -> None:
+    """A connection-related error in embed mode should not crash on missing host/port."""
+    mock_client_cls.side_effect = RuntimeError("connection refused by seekdb")
+
+    with pytest.raises(OceanBaseConnectionError) as exc_info:
+        OceanBaseStore(connection_args={"path": "/bad/path"})
+
+    assert exc_info.value.host == "localhost"
+    assert exc_info.value.port == "2881"
+
+
+@patch("langchain_oceanbase.store.ObVecClient")
+def test_embed_mode_non_connection_error_reraises(
+    mock_client_cls: MagicMock,
+) -> None:
+    """Non-connection errors in embed mode should re-raise as-is."""
+    mock_client_cls.side_effect = ValueError("invalid db_name")
+
+    with pytest.raises(ValueError, match="invalid db_name"):
+        OceanBaseStore(connection_args={"path": "/tmp/seekdb"})
+
+
+@patch("langchain_oceanbase.store.ObVecClient")
+def test_path_none_in_connection_args_uses_remote_mode(
+    mock_client_cls: MagicMock,
+) -> None:
+    """Explicit path=None in connection_args should use remote mode."""
+    OceanBaseStore(
+        connection_args={"path": None, "host": "myhost", "port": "1234"}
+    )
+
+    call_kwargs = mock_client_cls.call_args.kwargs
+    assert "path" not in call_kwargs
+    assert call_kwargs["uri"] == "myhost:1234"

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,3 @@
 version = 1
 revision = 3
-requires-python = ">=3.13"
+requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

- When `connection_args` contains a `path` key, `_create_client()` now creates `ObVecClient(path=..., db_name=...)` for in-process SeekDB instead of requiring remote host/port/user/password
- Applied the same pattern to both `OceanBaseCheckpointSaver` and `OceanBaseStore`
- Added 9 unit tests covering embed-mode routing, remote-mode defaults, kwargs forwarding, and error handling
- Updated `uv.lock` requires-python to `>=3.9`

## Test plan

- [ ] Unit tests pass: `python -m pytest tests/unit_tests/test_checkpointer_embed_mode.py -v`
- [ ] All existing unit tests still pass: `python -m pytest tests/unit_tests/ -v`
- [ ] Integration tests with embedded SeekDB (requires pyseekdb): `python -m pytest tests/integration_tests/test_checkpointer_embedded_seekdb.py -v`