### PR TITLE
chore(deps): bump pylibseekdb from 1.1.0 to 1.3.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3148,31 +3148,31 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylibseekdb"
-version = "1.3.0"
+version = "1.2.0"
 description = "An AI-Native Search Database. Unifies vector, text, structured and semi-structured data in a single engine, enabling hybrid search and in-database AI workflows."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "(sys_platform == \"linux\" or sys_platform == \"darwin\" and platform_machine == \"arm64\") and extra == \"pyseekdb\""
 files = [
-    {file = "pylibseekdb-1.3.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:492a53cf2e8504c0f3cc69406c171617b1a0e31b694c4cda594de18be1b4a87d"},
-    {file = "pylibseekdb-1.3.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:800e90d6978ba52846240311696453cbee3017803f9cf692c49867d207ac6dcc"},
-    {file = "pylibseekdb-1.3.0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:1d33cf82f34339bc58ac160688fc7d15ac2f7cbb226338d3887fe8350f65b762"},
-    {file = "pylibseekdb-1.3.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:77ba6786908cd8ab320ed4e5d5ef352759ef8990d72aff913467db5fe32542c4"},
-    {file = "pylibseekdb-1.3.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:4b127c21ac1178ab903735041b6afe25295731d7bcee9813e5e1576c9d384937"},
-    {file = "pylibseekdb-1.3.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:23cd6ad60a80543dfccb4dc9500401347b82fddb8cef10f5503e5eb816adb39f"},
-    {file = "pylibseekdb-1.3.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ec2465e206574f5dee7870bde2434a5ab9a03c2001786b1765fcb5dd790d6f98"},
-    {file = "pylibseekdb-1.3.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:1b78f26dfbb80157169b81f22ebb80957e3c6ee7b33e5ff35beaa4d628c33915"},
-    {file = "pylibseekdb-1.3.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:f6f739454aff786beeccfe71b66a0d89d01b5a8a260e0b8c5c30f8e9184bd88a"},
-    {file = "pylibseekdb-1.3.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:89069e1aeeb51f61aeaa0cf5d94bedb918f46c3476d7b30183dde7b2101e5954"},
-    {file = "pylibseekdb-1.3.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:2515ea14bbac59e6f9f90a43bbaf179050ad7f8ab683d1cb9fd7fe225ccdca4e"},
-    {file = "pylibseekdb-1.3.0-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:a4177a3a6369699c9791cef3a7bfe7b472af301352237ed6e4cea42034fc0047"},
-    {file = "pylibseekdb-1.3.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:8651b8e0324fa78a5ed93b9952f4140c968655c344ef11fdb20d754077efeb05"},
-    {file = "pylibseekdb-1.3.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e6e58bce51e709c46aae3891e723b786132da925b9b6362db4486c07044d99e8"},
-    {file = "pylibseekdb-1.3.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:ccf3f2c1bab07bde3489901fe0ee6e74562a839e001a5a24d71e6a8c561f7c9a"},
-    {file = "pylibseekdb-1.3.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:0e27371d77970ff97607ab4a50aec7da6566bd221abd7cef0f0a9de7a798afe5"},
-    {file = "pylibseekdb-1.3.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:78b22253d36d9ea16984165278c4a271347b82e79fb0259ce8da7d978ff33574"},
-    {file = "pylibseekdb-1.3.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:45fe3fe24225ab0f13fad3e5bed9c0c294181186a904e63a3763e14953c68716"},
+    {file = "pylibseekdb-1.2.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:b71d773b0f7efffbeb314b04e46adfbe27cf305b317441587da928d9a36d1218"},
+    {file = "pylibseekdb-1.2.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:e5d1adb43524014fc5de51853a52839a09d9ddb7842a79c0f5d1598a1a59d78e"},
+    {file = "pylibseekdb-1.2.0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:021aeb277da19a642dfe690015f118749921788f6aa854ecf0f0225b88653eb7"},
+    {file = "pylibseekdb-1.2.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:90f463bddea9b8daae7345bea25c73345a8c948c87aba55169df34d4eeb6e248"},
+    {file = "pylibseekdb-1.2.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ea2bcc12e0cbc8e1c56336cb5804c211acacbfcb0c81d807be6eefbffd07256f"},
+    {file = "pylibseekdb-1.2.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:322147c30f45ffd3b9cb40039559aa1f05bcb9b5b82eb22a8737f787828ed204"},
+    {file = "pylibseekdb-1.2.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6604951035ad97f4e4a6e78e6a90737b95497de9560f4297e43bcc1a1ffdccac"},
+    {file = "pylibseekdb-1.2.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d52078ca4b4e20f44006b2b362a9c20b76f4e88fab0d345c54002953228ab7c7"},
+    {file = "pylibseekdb-1.2.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:63148cffce8eea2c751e15d814f05876d79acf7c21d22b90000bce88b815ae3f"},
+    {file = "pylibseekdb-1.2.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:25bc0401f8a51a4c20091983ac674cb6d807ba5548bee00ff24d3d76b3cdbdfc"},
+    {file = "pylibseekdb-1.2.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:be7bee96cfdc2fb0947d943db5625e6dfb7e6234b2c827b8e7ced9feee9abd39"},
+    {file = "pylibseekdb-1.2.0-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:93f53fa7af74ca37df9eeedf190a49ad40cebacef3c98ae251467de339ff72e4"},
+    {file = "pylibseekdb-1.2.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:ae3390d2c58eeb1c773fb7d9d32c1502ac14bd22ceaf74ed5429edc3332b7447"},
+    {file = "pylibseekdb-1.2.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:f3ca63e4a750ea57eb2fafaa58e6cd0bb99a1e3edd73d41f7097b1089c1eb2ba"},
+    {file = "pylibseekdb-1.2.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:56d0ddeea292df513b46677017b2a2d24de86c28dbc186b85f2412cea1b66ef2"},
+    {file = "pylibseekdb-1.2.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:2e6d72206d3fcb3a2ffe8fab80c22b773aa7e6827fc11bfcd7c5af567df77ee3"},
+    {file = "pylibseekdb-1.2.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:1da00ecb9eebfaaf2da73f05d5159a314947525bd7706d080f2952edf003712d"},
+    {file = "pylibseekdb-1.2.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:8cf6a230c45d8bca6b5abc02e932fa667139394aff06aa1533271edcdd431fdb"},
 ]
 
 [[package]]
@@ -4824,4 +4824,4 @@ pyseekdb = ["pylibseekdb", "pyseekdb"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "975ca196289a538e97a7683584610206e7015af48fdc2a654be8f4ebd152bff1"
+content-hash = "55eca539009be6c83f563f8e8c65ad90851fdc9a99a4b2bc247e3c867f653c17"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3148,31 +3148,31 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylibseekdb"
-version = "1.1.0"
+version = "1.3.0"
 description = "An AI-Native Search Database. Unifies vector, text, structured and semi-structured data in a single engine, enabling hybrid search and in-database AI workflows."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "(sys_platform == \"linux\" or sys_platform == \"darwin\" and platform_machine == \"arm64\") and extra == \"pyseekdb\""
 files = [
-    {file = "pylibseekdb-1.1.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:beaed68943cb59d41c968086eff4efd018291ae5faa66e6b273794a28574d5cb"},
-    {file = "pylibseekdb-1.1.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:9902f008118b23a7c74747b013c382342ae245c3ea34b498e831319f81de02e9"},
-    {file = "pylibseekdb-1.1.0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:0a0ad03d87f1db1a7087ba89e398ce1ee00496e977d38c493104d0d517590968"},
-    {file = "pylibseekdb-1.1.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:e272bee013aabab152c4795676b3b0ba1107a8058f29a07d2a803168faea090c"},
-    {file = "pylibseekdb-1.1.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:116a28356532705ed262e2a7951ac8221ae8c97ade866fdab2df521dcca62530"},
-    {file = "pylibseekdb-1.1.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:d6ae33353e833cb56a7ce2cdb0305b872cdac9467eb79c277f82479c529b38ef"},
-    {file = "pylibseekdb-1.1.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9e2f8240b08a93e347d32534e7c394b7a151b67555a384eb88d73d4b0f8b9d14"},
-    {file = "pylibseekdb-1.1.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4d8615471bac39b1980951cbce0d742fa7bec676f28eb95f4db687fdd1e9c71b"},
-    {file = "pylibseekdb-1.1.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:d5688a0fe6fc703e5a707cbe0e139d570f1d34daff1491304d6b43154f2e12d9"},
-    {file = "pylibseekdb-1.1.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1e53d171246239bd526d1a1f9b3abef1ad9b10597bc1c0a2acf7e65afbd7d844"},
-    {file = "pylibseekdb-1.1.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:66d01ee9c0ad4a2e88ea2420f9c4d1ee9bb011b70c553a654c8a4e230e920ad7"},
-    {file = "pylibseekdb-1.1.0-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:11d2fbc98dcb8ec97257b949184dc09d9ba693811e77457bba9c8f80d282c265"},
-    {file = "pylibseekdb-1.1.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:ff05ac4bb13a4b5f9dd03771ded866beed72562ea497f68a4ae897c226afc446"},
-    {file = "pylibseekdb-1.1.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:065158b79192cce7635995a7599e99b21a3ff729cd6f68e31a65ed62f830bd3a"},
-    {file = "pylibseekdb-1.1.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:3f699867729b9cfe9d7835d45d7609c381512e4359c857cf3e0aaa5936344f15"},
-    {file = "pylibseekdb-1.1.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:67fddf5d6a46567f6081857ceae00e0c5c437ac3f5ebf7e664c0f7b452d2912f"},
-    {file = "pylibseekdb-1.1.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:2edcfdae2a00276eb76aa9da1eeb5f5fe7ccd43560cb195f2789fc36328d1744"},
-    {file = "pylibseekdb-1.1.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:4d9c4f033d1adaa14ead12a5f9da6eb48e5b36c2d63ff953f8f02c9287241af4"},
+    {file = "pylibseekdb-1.3.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:492a53cf2e8504c0f3cc69406c171617b1a0e31b694c4cda594de18be1b4a87d"},
+    {file = "pylibseekdb-1.3.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:800e90d6978ba52846240311696453cbee3017803f9cf692c49867d207ac6dcc"},
+    {file = "pylibseekdb-1.3.0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:1d33cf82f34339bc58ac160688fc7d15ac2f7cbb226338d3887fe8350f65b762"},
+    {file = "pylibseekdb-1.3.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:77ba6786908cd8ab320ed4e5d5ef352759ef8990d72aff913467db5fe32542c4"},
+    {file = "pylibseekdb-1.3.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:4b127c21ac1178ab903735041b6afe25295731d7bcee9813e5e1576c9d384937"},
+    {file = "pylibseekdb-1.3.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:23cd6ad60a80543dfccb4dc9500401347b82fddb8cef10f5503e5eb816adb39f"},
+    {file = "pylibseekdb-1.3.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ec2465e206574f5dee7870bde2434a5ab9a03c2001786b1765fcb5dd790d6f98"},
+    {file = "pylibseekdb-1.3.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:1b78f26dfbb80157169b81f22ebb80957e3c6ee7b33e5ff35beaa4d628c33915"},
+    {file = "pylibseekdb-1.3.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:f6f739454aff786beeccfe71b66a0d89d01b5a8a260e0b8c5c30f8e9184bd88a"},
+    {file = "pylibseekdb-1.3.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:89069e1aeeb51f61aeaa0cf5d94bedb918f46c3476d7b30183dde7b2101e5954"},
+    {file = "pylibseekdb-1.3.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:2515ea14bbac59e6f9f90a43bbaf179050ad7f8ab683d1cb9fd7fe225ccdca4e"},
+    {file = "pylibseekdb-1.3.0-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:a4177a3a6369699c9791cef3a7bfe7b472af301352237ed6e4cea42034fc0047"},
+    {file = "pylibseekdb-1.3.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:8651b8e0324fa78a5ed93b9952f4140c968655c344ef11fdb20d754077efeb05"},
+    {file = "pylibseekdb-1.3.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e6e58bce51e709c46aae3891e723b786132da925b9b6362db4486c07044d99e8"},
+    {file = "pylibseekdb-1.3.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:ccf3f2c1bab07bde3489901fe0ee6e74562a839e001a5a24d71e6a8c561f7c9a"},
+    {file = "pylibseekdb-1.3.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:0e27371d77970ff97607ab4a50aec7da6566bd221abd7cef0f0a9de7a798afe5"},
+    {file = "pylibseekdb-1.3.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:78b22253d36d9ea16984165278c4a271347b82e79fb0259ce8da7d978ff33574"},
+    {file = "pylibseekdb-1.3.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:45fe3fe24225ab0f13fad3e5bed9c0c294181186a904e63a3763e14953c68716"},
 ]
 
 [[package]]
@@ -4824,4 +4824,4 @@ pyseekdb = ["pylibseekdb", "pyseekdb"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "ae820e816cb505f8fbc446885ce8b82187b6ae645e5a8fb021ab7f12bd958b40"
+content-hash = "975ca196289a538e97a7683584610206e7015af48fdc2a654be8f4ebd152bff1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3148,31 +3148,31 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylibseekdb"
-version = "1.2.0"
+version = "1.3.0"
 description = "An AI-Native Search Database. Unifies vector, text, structured and semi-structured data in a single engine, enabling hybrid search and in-database AI workflows."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "(sys_platform == \"linux\" or sys_platform == \"darwin\" and platform_machine == \"arm64\") and extra == \"pyseekdb\""
 files = [
-    {file = "pylibseekdb-1.2.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:b71d773b0f7efffbeb314b04e46adfbe27cf305b317441587da928d9a36d1218"},
-    {file = "pylibseekdb-1.2.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:e5d1adb43524014fc5de51853a52839a09d9ddb7842a79c0f5d1598a1a59d78e"},
-    {file = "pylibseekdb-1.2.0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:021aeb277da19a642dfe690015f118749921788f6aa854ecf0f0225b88653eb7"},
-    {file = "pylibseekdb-1.2.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:90f463bddea9b8daae7345bea25c73345a8c948c87aba55169df34d4eeb6e248"},
-    {file = "pylibseekdb-1.2.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ea2bcc12e0cbc8e1c56336cb5804c211acacbfcb0c81d807be6eefbffd07256f"},
-    {file = "pylibseekdb-1.2.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:322147c30f45ffd3b9cb40039559aa1f05bcb9b5b82eb22a8737f787828ed204"},
-    {file = "pylibseekdb-1.2.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6604951035ad97f4e4a6e78e6a90737b95497de9560f4297e43bcc1a1ffdccac"},
-    {file = "pylibseekdb-1.2.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d52078ca4b4e20f44006b2b362a9c20b76f4e88fab0d345c54002953228ab7c7"},
-    {file = "pylibseekdb-1.2.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:63148cffce8eea2c751e15d814f05876d79acf7c21d22b90000bce88b815ae3f"},
-    {file = "pylibseekdb-1.2.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:25bc0401f8a51a4c20091983ac674cb6d807ba5548bee00ff24d3d76b3cdbdfc"},
-    {file = "pylibseekdb-1.2.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:be7bee96cfdc2fb0947d943db5625e6dfb7e6234b2c827b8e7ced9feee9abd39"},
-    {file = "pylibseekdb-1.2.0-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:93f53fa7af74ca37df9eeedf190a49ad40cebacef3c98ae251467de339ff72e4"},
-    {file = "pylibseekdb-1.2.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:ae3390d2c58eeb1c773fb7d9d32c1502ac14bd22ceaf74ed5429edc3332b7447"},
-    {file = "pylibseekdb-1.2.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:f3ca63e4a750ea57eb2fafaa58e6cd0bb99a1e3edd73d41f7097b1089c1eb2ba"},
-    {file = "pylibseekdb-1.2.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:56d0ddeea292df513b46677017b2a2d24de86c28dbc186b85f2412cea1b66ef2"},
-    {file = "pylibseekdb-1.2.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:2e6d72206d3fcb3a2ffe8fab80c22b773aa7e6827fc11bfcd7c5af567df77ee3"},
-    {file = "pylibseekdb-1.2.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:1da00ecb9eebfaaf2da73f05d5159a314947525bd7706d080f2952edf003712d"},
-    {file = "pylibseekdb-1.2.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:8cf6a230c45d8bca6b5abc02e932fa667139394aff06aa1533271edcdd431fdb"},
+    {file = "pylibseekdb-1.3.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:492a53cf2e8504c0f3cc69406c171617b1a0e31b694c4cda594de18be1b4a87d"},
+    {file = "pylibseekdb-1.3.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:800e90d6978ba52846240311696453cbee3017803f9cf692c49867d207ac6dcc"},
+    {file = "pylibseekdb-1.3.0-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:1d33cf82f34339bc58ac160688fc7d15ac2f7cbb226338d3887fe8350f65b762"},
+    {file = "pylibseekdb-1.3.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:77ba6786908cd8ab320ed4e5d5ef352759ef8990d72aff913467db5fe32542c4"},
+    {file = "pylibseekdb-1.3.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:4b127c21ac1178ab903735041b6afe25295731d7bcee9813e5e1576c9d384937"},
+    {file = "pylibseekdb-1.3.0-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:23cd6ad60a80543dfccb4dc9500401347b82fddb8cef10f5503e5eb816adb39f"},
+    {file = "pylibseekdb-1.3.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ec2465e206574f5dee7870bde2434a5ab9a03c2001786b1765fcb5dd790d6f98"},
+    {file = "pylibseekdb-1.3.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:1b78f26dfbb80157169b81f22ebb80957e3c6ee7b33e5ff35beaa4d628c33915"},
+    {file = "pylibseekdb-1.3.0-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:f6f739454aff786beeccfe71b66a0d89d01b5a8a260e0b8c5c30f8e9184bd88a"},
+    {file = "pylibseekdb-1.3.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:89069e1aeeb51f61aeaa0cf5d94bedb918f46c3476d7b30183dde7b2101e5954"},
+    {file = "pylibseekdb-1.3.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:2515ea14bbac59e6f9f90a43bbaf179050ad7f8ab683d1cb9fd7fe225ccdca4e"},
+    {file = "pylibseekdb-1.3.0-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:a4177a3a6369699c9791cef3a7bfe7b472af301352237ed6e4cea42034fc0047"},
+    {file = "pylibseekdb-1.3.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:8651b8e0324fa78a5ed93b9952f4140c968655c344ef11fdb20d754077efeb05"},
+    {file = "pylibseekdb-1.3.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e6e58bce51e709c46aae3891e723b786132da925b9b6362db4486c07044d99e8"},
+    {file = "pylibseekdb-1.3.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:ccf3f2c1bab07bde3489901fe0ee6e74562a839e001a5a24d71e6a8c561f7c9a"},
+    {file = "pylibseekdb-1.3.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:0e27371d77970ff97607ab4a50aec7da6566bd221abd7cef0f0a9de7a798afe5"},
+    {file = "pylibseekdb-1.3.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:78b22253d36d9ea16984165278c4a271347b82e79fb0259ce8da7d978ff33574"},
+    {file = "pylibseekdb-1.3.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:45fe3fe24225ab0f13fad3e5bed9c0c294181186a904e63a3763e14953c68716"},
 ]
 
 [[package]]
@@ -4824,4 +4824,4 @@ pyseekdb = ["pylibseekdb", "pyseekdb"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "55eca539009be6c83f563f8e8c65ad90851fdc9a99a4b2bc247e3c867f653c17"
+content-hash = "975ca196289a538e97a7683584610206e7015af48fdc2a654be8f4ebd152bff1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ langgraph-checkpoint = ">=3.0.1,<5.0.0"
 # >=1.2: unified SeekDB client. Constrain pylibseekdb so the lock resolves to 1.1+ (manylinux + macOS arm64 wheels);
 # 1.0.0.post1 is Linux-wheel-only metadata and breaks Poetry on macOS arm64 / some CI installers.
 pyseekdb = { version = ">=1.2.0.post1,<3", optional = true }
-# Pin 1.2.0 to check whether the embedded SeekDB regression starts before 1.3.0.
-pylibseekdb = { version = "1.2.0", optional = true, markers = "sys_platform == 'linux' or (sys_platform == 'darwin' and platform_machine == 'arm64')" }
+# Relax cap to retest embedded SeekDB with the newer pyseekdb/pyobvector stack on develop.
+pylibseekdb = { version = ">=1.1.0,<1.4", optional = true, markers = "sys_platform == 'linux' or (sys_platform == 'darwin' and platform_machine == 'arm64')" }
 pyobvector = [
     { version = ">=0.2.25" },
     { version = ">=0.2.25", extras = ["pyseekdb"], markers = "extra == 'pyseekdb'" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ langgraph-checkpoint = ">=3.0.1,<5.0.0"
 # >=1.2: unified SeekDB client. Constrain pylibseekdb so the lock resolves to 1.1+ (manylinux + macOS arm64 wheels);
 # 1.0.0.post1 is Linux-wheel-only metadata and breaks Poetry on macOS arm64 / some CI installers.
 pyseekdb = { version = ">=1.2.0.post1,<3", optional = true }
-# Relax cap to retest embedded SeekDB with the newer pyseekdb/pyobvector stack on develop.
-pylibseekdb = { version = ">=1.1.0,<1.4", optional = true, markers = "sys_platform == 'linux' or (sys_platform == 'darwin' and platform_machine == 'arm64')" }
+# Pin 1.2.0 to check whether the embedded SeekDB regression starts before 1.3.0.
+pylibseekdb = { version = "1.2.0", optional = true, markers = "sys_platform == 'linux' or (sys_platform == 'darwin' and platform_machine == 'arm64')" }
 pyobvector = [
     { version = ">=0.2.25" },
     { version = ">=0.2.25", extras = ["pyseekdb"], markers = "extra == 'pyseekdb'" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ langgraph-checkpoint = ">=3.0.1,<5.0.0"
 # >=1.2: unified SeekDB client. Constrain pylibseekdb so the lock resolves to 1.1+ (manylinux + macOS arm64 wheels);
 # 1.0.0.post1 is Linux-wheel-only metadata and breaks Poetry on macOS arm64 / some CI installers.
 pyseekdb = { version = ">=1.2.0.post1,<3", optional = true }
-# Cap <1.2: pylibseekdb 1.2+ wheels are manylinux-only; 1.1.x includes macOS arm64 for local dev + Linux for CI
-pylibseekdb = { version = ">=1.1.0,<1.2", optional = true, markers = "sys_platform == 'linux' or (sys_platform == 'darwin' and platform_machine == 'arm64')" }
+# Relax cap to retest embedded SeekDB with the newer pyseekdb/pyobvector stack on develop.
+pylibseekdb = { version = ">=1.1.0,<1.4", optional = true, markers = "sys_platform == 'linux' or (sys_platform == 'darwin' and platform_machine == 'arm64')" }
 pyobvector = [
     { version = ">=0.2.25" },
     { version = ">=0.2.25", extras = ["pyseekdb"], markers = "extra == 'pyseekdb'" },


### PR DESCRIPTION
## Summary
- retry the `pylibseekdb` 1.3.0 bump on top of the current `develop` dependency stack
- relax the `pylibseekdb` constraint from `<1.2` to `<1.4`
- refresh the lockfile to resolve `pylibseekdb` 1.3.0

## Context
PR #129 was closed after embedded SeekDB CI jobs segfaulted on the older dependency stack. Since then, related dependency bumps have landed on `develop`, including `pyseekdb 1.3.0` and `pyobvector 0.2.28` via #137 plus the other queued bump PRs.

A follow-up retry with `pylibseekdb 1.2.0` also reproduced embedded-only segfaults, so this PR is restored to `1.3.0` and paired with an upstream bug report.

## Verification
- `python3` metadata check for `pyproject.toml` and `poetry.lock`
- `uvx poetry check --lock`
- `git diff --check`

The meaningful validation remains GitHub CI, especially the embedded SeekDB matrix jobs that fail in this PR.
