### PR TITLE
fix: use thread pool executor for async checkpointer methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,21 @@
-__pycache__
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
 .mypy_cache
 .pytest_cache
 .ruff_cache
+
+# Distribution / packaging
+dist/
+build/
+*.egg-info/
+*.egg
+
+# Virtual environments
+venv/
+.venv/
+env/
 
 # Coverage
 .coverage
@@ -16,3 +30,9 @@ coverage.xml
 .cursor/
 .idea/
 .worktrees/
+.env
+.env.*
+
+# OS
+.DS_Store
+Thumbs.db

--- a/langchain_oceanbase/checkpointer.py
+++ b/langchain_oceanbase/checkpointer.py
@@ -233,6 +233,35 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         self._kwargs = kwargs
         self._create_client(**kwargs)
 
+    def close(self) -> None:
+        """Shut down the thread pool executor backing the async methods.
+
+        Safe to call multiple times. After calling, the async methods can no
+        longer be used. Prefer using the saver as a (async) context manager so
+        this is invoked automatically.
+        """
+        self._executor.shutdown(wait=True)
+
+    def __enter__(self) -> "OceanBaseCheckpointSaver":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "OceanBaseCheckpointSaver":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        # Best-effort cleanup so a saver that was neither closed nor used as a
+        # context manager does not leak its worker threads. Never wait or raise
+        # from a finalizer.
+        executor = getattr(self, "_executor", None)
+        if executor is not None:
+            executor.shutdown(wait=False)
+
     def _create_client(self, **kwargs: Any) -> None:
         """Create and initialize the OceanBase vector client.
 
@@ -370,10 +399,16 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
             self._ensure_required_indexes(conn)
             conn.commit()
 
+    async def _run(self, func: Any, /, *args: Any, **kwargs: Any) -> Any:
+        """Run a blocking callable on the executor without blocking the loop."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._executor, partial(func, *args, **kwargs)
+        )
+
     async def asetup(self) -> None:
         """Async version of setup using a thread pool executor."""
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(self._executor, self.setup)
+        await self._run(self.setup)
 
     @staticmethod
     def _is_duplicate_index_error(exc: Exception) -> bool:
@@ -419,8 +454,7 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
 
     async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
         """Async version of get_tuple using a thread pool executor."""
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(self._executor, self.get_tuple, config)
+        return await self._run(self.get_tuple, config)
 
     async def alist(
         self,
@@ -431,17 +465,11 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         limit: Optional[int] = None,
     ) -> AsyncIterator[CheckpointTuple]:
         """Async version of list using a thread pool executor."""
-        loop = asyncio.get_running_loop()
-        items = await loop.run_in_executor(
-            self._executor,
-            partial(
-                lambda *a, **kw: list(self.list(*a, **kw)),
-                config,
-                filter=filter,
-                before=before,
-                limit=limit,
-            ),
-        )
+
+        def _list_sync() -> list[CheckpointTuple]:
+            return list(self.list(config, filter=filter, before=before, limit=limit))
+
+        items = await self._run(_list_sync)
         for item in items:
             yield item
 
@@ -453,11 +481,7 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         new_versions: ChannelVersions,
     ) -> RunnableConfig:
         """Async version of put using a thread pool executor."""
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(
-            self._executor,
-            partial(self.put, config, checkpoint, metadata, new_versions),
-        )
+        return await self._run(self.put, config, checkpoint, metadata, new_versions)
 
     async def aput_writes(
         self,
@@ -467,16 +491,11 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         task_path: str = "",
     ) -> None:
         """Async version of put_writes using a thread pool executor."""
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            self._executor,
-            partial(self.put_writes, config, writes, task_id, task_path),
-        )
+        await self._run(self.put_writes, config, writes, task_id, task_path)
 
     async def adelete_thread(self, thread_id: str) -> None:
         """Async version of delete_thread using a thread pool executor."""
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(self._executor, self.delete_thread, thread_id)
+        await self._run(self.delete_thread, thread_id)
 
     async def aprune(
         self,
@@ -485,11 +504,7 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         strategy: str = "keep_latest",
     ) -> None:
         """Async version of prune using a thread pool executor."""
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            self._executor,
-            partial(self.prune, thread_ids, strategy=strategy),
-        )
+        await self._run(self.prune, thread_ids, strategy=strategy)
 
     def get_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
         """Get a checkpoint tuple from the database.

--- a/langchain_oceanbase/checkpointer.py
+++ b/langchain_oceanbase/checkpointer.py
@@ -7,13 +7,16 @@ their state within and across multiple interactions.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import logging
 import random
 import threading
 from collections.abc import AsyncIterator, Iterator, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from functools import partial
 from typing import Any, Dict, Optional, cast
 
 from langchain_core.runnables import RunnableConfig
@@ -192,12 +195,14 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
     """
 
     lock: threading.Lock
+    _executor: ThreadPoolExecutor
 
     def __init__(
         self,
         connection_args: Optional[Dict[str, Any]] = None,
         *,
         serde: Optional[SerializerProtocol] = None,
+        max_workers: Optional[int] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the OceanBase checkpoint saver.
@@ -213,6 +218,8 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
                   in-process SeekDB instead of a remote connection.
                   Requires ``pip install langchain-oceanbase[pyseekdb]``.
             serde: Optional serializer for encoding/decoding checkpoints.
+            max_workers: Maximum number of threads in the executor pool
+                for async operations. Defaults to None (uses Python's default).
             **kwargs: Additional arguments passed to ObVecClient.
         """
         super().__init__(serde=serde)
@@ -222,6 +229,7 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
             else DEFAULT_OCEANBASE_CONNECTION
         )
         self.lock = threading.Lock()
+        self._executor = ThreadPoolExecutor(max_workers=max_workers)
         self._kwargs = kwargs
         self._create_client(**kwargs)
 
@@ -362,6 +370,11 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
             self._ensure_required_indexes(conn)
             conn.commit()
 
+    async def asetup(self) -> None:
+        """Async version of setup using a thread pool executor."""
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(self._executor, self.setup)
+
     @staticmethod
     def _is_duplicate_index_error(exc: Exception) -> bool:
         """Return True when an index DDL failed because the index already exists."""
@@ -405,8 +418,9 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
                     raise
 
     async def aget_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
-        """Async wrapper for get_tuple."""
-        return self.get_tuple(config)
+        """Async version of get_tuple using a thread pool executor."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self._executor, self.get_tuple, config)
 
     async def alist(
         self,
@@ -416,8 +430,18 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         before: Optional[RunnableConfig] = None,
         limit: Optional[int] = None,
     ) -> AsyncIterator[CheckpointTuple]:
-        """Async wrapper for list."""
-        items = list(self.list(config, filter=filter, before=before, limit=limit))
+        """Async version of list using a thread pool executor."""
+        loop = asyncio.get_running_loop()
+        items = await loop.run_in_executor(
+            self._executor,
+            partial(
+                lambda *a, **kw: list(self.list(*a, **kw)),
+                config,
+                filter=filter,
+                before=before,
+                limit=limit,
+            ),
+        )
         for item in items:
             yield item
 
@@ -428,8 +452,12 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         metadata: CheckpointMetadata,
         new_versions: ChannelVersions,
     ) -> RunnableConfig:
-        """Async wrapper for put."""
-        return self.put(config, checkpoint, metadata, new_versions)
+        """Async version of put using a thread pool executor."""
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            self._executor,
+            partial(self.put, config, checkpoint, metadata, new_versions),
+        )
 
     async def aput_writes(
         self,
@@ -438,12 +466,17 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         task_id: str,
         task_path: str = "",
     ) -> None:
-        """Async wrapper for put_writes."""
-        self.put_writes(config, writes, task_id, task_path)
+        """Async version of put_writes using a thread pool executor."""
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            self._executor,
+            partial(self.put_writes, config, writes, task_id, task_path),
+        )
 
     async def adelete_thread(self, thread_id: str) -> None:
-        """Async wrapper for delete_thread."""
-        self.delete_thread(thread_id)
+        """Async version of delete_thread using a thread pool executor."""
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(self._executor, self.delete_thread, thread_id)
 
     async def aprune(
         self,
@@ -451,8 +484,12 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         *,
         strategy: str = "keep_latest",
     ) -> None:
-        """Async wrapper for prune."""
-        self.prune(thread_ids, strategy=strategy)
+        """Async version of prune using a thread pool executor."""
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            self._executor,
+            partial(self.prune, thread_ids, strategy=strategy),
+        )
 
     def get_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
         """Get a checkpoint tuple from the database.

--- a/tests/integration_tests/test_checkpoint.py
+++ b/tests/integration_tests/test_checkpoint.py
@@ -1,3 +1,4 @@
+import os
 import time
 import uuid
 
@@ -5,10 +6,15 @@ import pytest
 from langchain_core.messages import HumanMessage
 
 from langchain_oceanbase.checkpoint import OceanBaseSaver
-from langchain_oceanbase.vectorstores import DEFAULT_OCEANBASE_CONNECTION
 
-# Define connection args (should match your environment)
-CONNECTION_ARGS = DEFAULT_OCEANBASE_CONNECTION
+# Define connection args from environment (falls back to defaults)
+CONNECTION_ARGS = {
+    "host": os.getenv("OB_HOST", "127.0.0.1"),
+    "port": os.getenv("OB_PORT", "2881"),
+    "user": os.getenv("OB_USER", "root@test"),
+    "password": os.getenv("OB_PASSWORD", ""),
+    "db_name": os.getenv("OB_DB", "test"),
+}
 
 
 @pytest.fixture

--- a/tests/unit_tests/test_checkpointer_async_api.py
+++ b/tests/unit_tests/test_checkpointer_async_api.py
@@ -209,14 +209,15 @@ async def test_aprune_delegates_to_sync_method(
 
 
 @pytest.mark.asyncio
-async def test_async_methods_run_off_the_event_loop_thread(
+async def test_aget_tuple_runs_off_the_event_loop_thread(
     saver: OceanBaseCheckpointSaver,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The sync work must run on an executor thread, not the loop thread.
 
     This is the only behavior the thread-pool wrappers add over a plain inline
-    call, so it is asserted explicitly.
+    call. All async methods share the same ``_run`` offload path, so asserting
+    it for one representative method covers the contract.
     """
     loop_thread_id = threading.get_ident()
     observed: dict[str, int] = {}
@@ -233,12 +234,47 @@ async def test_async_methods_run_off_the_event_loop_thread(
     assert observed["thread_id"] != loop_thread_id
 
 
+@pytest.mark.asyncio
+async def test_async_method_propagates_sync_exception(
+    saver: OceanBaseCheckpointSaver,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exceptions raised in the sync method must surface through the executor.
+
+    All async methods share ``_run``; offloading to the executor must not
+    swallow or re-wrap the original exception.
+    """
+
+    def boom(_config: RunnableConfig) -> None:
+        raise ValueError("sync failure")
+
+    monkeypatch.setattr(saver, "get_tuple", boom)
+
+    config: RunnableConfig = {"configurable": {"thread_id": "t", "checkpoint_ns": ""}}
+    with pytest.raises(ValueError, match="sync failure"):
+        await saver.aget_tuple(config)
+
+
+@pytest.mark.asyncio
+async def test_async_method_after_close_raises(
+    saver: OceanBaseCheckpointSaver,
+) -> None:
+    """Calling an async method after close() must raise, per the documented contract."""
+    saver.close()
+
+    config: RunnableConfig = {"configurable": {"thread_id": "t", "checkpoint_ns": ""}}
+    with pytest.raises(RuntimeError):
+        await saver.aget_tuple(config)
+
+
 def test_close_shuts_down_executor_and_is_idempotent(
     saver: OceanBaseCheckpointSaver,
 ) -> None:
     """close() should shut the executor down and tolerate repeated calls."""
     saver.close()
-    assert saver._executor._shutdown is True
+    # Observable effect: the executor refuses new work after shutdown.
+    with pytest.raises(RuntimeError):
+        saver._executor.submit(lambda: None)
     # Second call must not raise.
     saver.close()
 
@@ -252,8 +288,9 @@ def test_context_manager_closes_executor(
     )
     with OceanBaseCheckpointSaver(connection_args={}) as saver:
         executor = saver._executor
-        assert executor._shutdown is False
-    assert executor._shutdown is True
+        assert executor.submit(lambda: None).result() is None
+    with pytest.raises(RuntimeError):
+        executor.submit(lambda: None)
 
 
 @pytest.mark.asyncio
@@ -266,5 +303,6 @@ async def test_async_context_manager_closes_executor(
     )
     async with OceanBaseCheckpointSaver(connection_args={}) as saver:
         executor = saver._executor
-        assert executor._shutdown is False
-    assert executor._shutdown is True
+        assert executor.submit(lambda: None).result() is None
+    with pytest.raises(RuntimeError):
+        executor.submit(lambda: None)

--- a/tests/unit_tests/test_checkpointer_async_api.py
+++ b/tests/unit_tests/test_checkpointer_async_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from typing import cast
 from unittest.mock import MagicMock
 
@@ -123,3 +124,147 @@ def test_prepare_metadata_matches_langgraph_serialization_rules(
     assert "thread_id" not in prepared
     assert "checkpoint_id" not in prepared
     assert "checkpoint_ns" not in prepared
+
+
+@pytest.mark.asyncio
+async def test_asetup_delegates_to_sync_method(
+    saver: OceanBaseCheckpointSaver,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """asetup should delegate to setup."""
+    setup = MagicMock()
+    monkeypatch.setattr(saver, "setup", setup)
+
+    await saver.asetup()
+
+    setup.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_aput_delegates_to_sync_method(
+    saver: OceanBaseCheckpointSaver,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """aput should delegate to put and propagate its return value."""
+    expected = MagicMock(name="next_config")
+    put = MagicMock(return_value=expected)
+    monkeypatch.setattr(saver, "put", put)
+
+    config: RunnableConfig = {"configurable": {"thread_id": "t", "checkpoint_ns": ""}}
+    checkpoint = MagicMock(name="checkpoint")
+    metadata = cast(CheckpointMetadata, {"source": "loop"})
+    new_versions = MagicMock(name="new_versions")
+
+    result = await saver.aput(config, checkpoint, metadata, new_versions)
+
+    put.assert_called_once_with(config, checkpoint, metadata, new_versions)
+    assert result is expected
+
+
+@pytest.mark.asyncio
+async def test_aput_writes_delegates_to_sync_method(
+    saver: OceanBaseCheckpointSaver,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """aput_writes should delegate to put_writes."""
+    put_writes = MagicMock()
+    monkeypatch.setattr(saver, "put_writes", put_writes)
+
+    config: RunnableConfig = {
+        "configurable": {"thread_id": "t", "checkpoint_id": "cp-1"}
+    }
+    writes = [("channel-1", "value-1")]
+
+    await saver.aput_writes(config, writes, "task-1", "task-path")
+
+    put_writes.assert_called_once_with(config, writes, "task-1", "task-path")
+
+
+@pytest.mark.asyncio
+async def test_adelete_thread_delegates_to_sync_method(
+    saver: OceanBaseCheckpointSaver,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """adelete_thread should delegate to delete_thread."""
+    delete_thread = MagicMock()
+    monkeypatch.setattr(saver, "delete_thread", delete_thread)
+
+    await saver.adelete_thread("thread-1")
+
+    delete_thread.assert_called_once_with("thread-1")
+
+
+@pytest.mark.asyncio
+async def test_aprune_delegates_to_sync_method(
+    saver: OceanBaseCheckpointSaver,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """aprune should delegate to prune and forward the strategy kwarg."""
+    prune = MagicMock()
+    monkeypatch.setattr(saver, "prune", prune)
+
+    await saver.aprune(["thread-1", "thread-2"], strategy="delete")
+
+    prune.assert_called_once_with(["thread-1", "thread-2"], strategy="delete")
+
+
+@pytest.mark.asyncio
+async def test_async_methods_run_off_the_event_loop_thread(
+    saver: OceanBaseCheckpointSaver,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sync work must run on an executor thread, not the loop thread.
+
+    This is the only behavior the thread-pool wrappers add over a plain inline
+    call, so it is asserted explicitly.
+    """
+    loop_thread_id = threading.get_ident()
+    observed: dict[str, int] = {}
+
+    def record_thread(_config: RunnableConfig) -> None:
+        observed["thread_id"] = threading.get_ident()
+        return None
+
+    monkeypatch.setattr(saver, "get_tuple", record_thread)
+
+    config: RunnableConfig = {"configurable": {"thread_id": "t", "checkpoint_ns": ""}}
+    await saver.aget_tuple(config)
+
+    assert observed["thread_id"] != loop_thread_id
+
+
+def test_close_shuts_down_executor_and_is_idempotent(
+    saver: OceanBaseCheckpointSaver,
+) -> None:
+    """close() should shut the executor down and tolerate repeated calls."""
+    saver.close()
+    assert saver._executor._shutdown is True
+    # Second call must not raise.
+    saver.close()
+
+
+def test_context_manager_closes_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Using the saver as a context manager should shut the executor down."""
+    monkeypatch.setattr(
+        OceanBaseCheckpointSaver, "_create_client", lambda self, **_: None
+    )
+    with OceanBaseCheckpointSaver(connection_args={}) as saver:
+        executor = saver._executor
+        assert executor._shutdown is False
+    assert executor._shutdown is True
+
+
+@pytest.mark.asyncio
+async def test_async_context_manager_closes_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Using the saver as an async context manager should shut the executor down."""
+    monkeypatch.setattr(
+        OceanBaseCheckpointSaver, "_create_client", lambda self, **_: None
+    )
+    async with OceanBaseCheckpointSaver(connection_args={}) as saver:
+        executor = saver._executor
+        assert executor._shutdown is False
+    assert executor._shutdown is True


### PR DESCRIPTION
## Summary
- Wrap all async checkpointer methods (aget_tuple, alist, aput, aput_writes, adelete_thread, aprune) with loop.run_in_executor() backed by a configurable ThreadPoolExecutor, replacing the previous direct sync calls that blocked the event loop
- Add asetup() async method for non-blocking migration setup
- Update test_checkpoint.py to read connection args from environment variables instead of importing the hardcoded default

 Motivation

  The embedded SeekDB backend (pylibseekdb) is an in-process database — aiomysql cannot connect to it since there is no network listener. The previous async methods either blocked the event loop or were simply incompatible with embedded mode. This is a pragmatic fix; a follow-up issue tracks migrating the remote backend to a native async driver. 

