### PR TITLE
feat: support copy_thread and delete_for_runs checkpoint capabilities

### DIFF
--- a/langchain_oceanbase/checkpointer.py
+++ b/langchain_oceanbase/checkpointer.py
@@ -1214,6 +1214,9 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
             if not matched:
                 return
 
+            # Cascade off the matched keys with an OR-of-tuples predicate. A
+            # run_id maps to only a handful of checkpoints (roughly one per
+            # namespace), so this stays small; batch it if that ever changes.
             key_params: Dict[str, Any] = {}
             conditions = []
             for idx, (thread_id, checkpoint_ns, checkpoint_id) in enumerate(matched):

--- a/langchain_oceanbase/checkpointer.py
+++ b/langchain_oceanbase/checkpointer.py
@@ -506,9 +506,7 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         """Async version of prune using a thread pool executor."""
         await self._run(self.prune, thread_ids, strategy=strategy)
 
-    async def acopy_thread(
-        self, source_thread_id: str, target_thread_id: str
-    ) -> None:
+    async def acopy_thread(self, source_thread_id: str, target_thread_id: str) -> None:
         """Async version of copy_thread using a thread pool executor."""
         await self._run(self.copy_thread, source_thread_id, target_thread_id)
 
@@ -1104,7 +1102,9 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         Copies the complete parent chain (every ancestor checkpoint and its
         blobs and writes), preserving namespaces, ordering, metadata, channel
         values and pending writes. Only ``thread_id`` is rewritten. If the
-        source thread has no checkpoints this is a no-op.
+        source thread has no checkpoints this is a no-op. Rows already present
+        on the target are left untouched (``INSERT IGNORE``), so a repeated copy
+        is idempotent.
 
         Args:
             source_thread_id: The thread ID to copy from.
@@ -1115,11 +1115,15 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
 
                 checkpointer.copy_thread("thread-a", "thread-b")
         """
+        params = {
+            "source_thread_id": source_thread_id,
+            "target_thread_id": target_thread_id,
+        }
         with self._cursor() as conn:
             conn.execute(
                 text(
                     """
-                    INSERT INTO checkpoints
+                    INSERT IGNORE INTO checkpoints
                     (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id,
                      `type`, checkpoint, metadata)
                     SELECT :target_thread_id, checkpoint_ns, checkpoint_id,
@@ -1128,15 +1132,12 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
                     WHERE thread_id = :source_thread_id
                     """
                 ),
-                {
-                    "source_thread_id": source_thread_id,
-                    "target_thread_id": target_thread_id,
-                },
+                params,
             )
             conn.execute(
                 text(
                     """
-                    INSERT INTO checkpoint_blobs
+                    INSERT IGNORE INTO checkpoint_blobs
                     (thread_id, checkpoint_ns, channel, version, `type`, `blob`)
                     SELECT :target_thread_id, checkpoint_ns, channel, version,
                            `type`, `blob`
@@ -1144,15 +1145,12 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
                     WHERE thread_id = :source_thread_id
                     """
                 ),
-                {
-                    "source_thread_id": source_thread_id,
-                    "target_thread_id": target_thread_id,
-                },
+                params,
             )
             conn.execute(
                 text(
                     """
-                    INSERT INTO checkpoint_writes
+                    INSERT IGNORE INTO checkpoint_writes
                     (thread_id, checkpoint_ns, checkpoint_id, task_id, task_path,
                      idx, channel, `type`, `blob`)
                     SELECT :target_thread_id, checkpoint_ns, checkpoint_id, task_id,
@@ -1161,10 +1159,7 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
                     WHERE thread_id = :source_thread_id
                     """
                 ),
-                {
-                    "source_thread_id": source_thread_id,
-                    "target_thread_id": target_thread_id,
-                },
+                params,
             )
             conn.commit()
 
@@ -1173,9 +1168,13 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
 
         ``run_id`` is stored inside each checkpoint's ``metadata`` JSON (it flows
         from ``config["metadata"]["run_id"]``). Checkpoints whose metadata
-        ``run_id`` matches are deleted together with their pending writes and
-        channel blobs, across all namespaces. An empty list or unknown run IDs
-        are a no-op.
+        ``run_id`` matches are deleted together with their pending writes,
+        across all namespaces. An empty list or unknown run IDs are a no-op.
+
+        Channel blobs are content-addressed by ``(thread_id, checkpoint_ns,
+        channel, version)`` and shared across the checkpoints of a thread, so
+        they are not removed here; reclaim them with :meth:`prune` or
+        :meth:`delete_thread`.
 
         Args:
             run_ids: The run IDs whose checkpoints should be deleted.
@@ -1197,8 +1196,8 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
                 placeholders.append(f":{key}")
             run_id_filter = ", ".join(placeholders)
 
-            # Identify the checkpoints produced by these runs. blobs/writes carry
-            # no run_id, so cascade deletes key off the matched checkpoint rows.
+            # blobs/writes carry no run_id, so identify the checkpoints produced
+            # by these runs once and cascade deletes off the matched keys.
             matched = self._result_fetchall(
                 conn.execute(
                     text(
@@ -1215,32 +1214,22 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
             if not matched:
                 return
 
-            for thread_id, checkpoint_ns, checkpoint_id in matched:
-                key_params = {
-                    "thread_id": thread_id,
-                    "checkpoint_ns": checkpoint_ns,
-                    "checkpoint_id": checkpoint_id,
-                }
-                conn.execute(
-                    text(
-                        """
-                        DELETE FROM checkpoints
-                        WHERE thread_id = :thread_id
-                          AND checkpoint_ns = :checkpoint_ns
-                          AND checkpoint_id = :checkpoint_id
-                        """
-                    ),
-                    key_params,
+            key_params: Dict[str, Any] = {}
+            conditions = []
+            for idx, (thread_id, checkpoint_ns, checkpoint_id) in enumerate(matched):
+                key_params[f"thread_id_{idx}"] = thread_id
+                key_params[f"checkpoint_ns_{idx}"] = checkpoint_ns
+                key_params[f"checkpoint_id_{idx}"] = checkpoint_id
+                conditions.append(
+                    f"(thread_id = :thread_id_{idx} "
+                    f"AND checkpoint_ns = :checkpoint_ns_{idx} "
+                    f"AND checkpoint_id = :checkpoint_id_{idx})"
                 )
+            where_clause = " OR ".join(conditions)
+
+            for table in ("checkpoint_writes", "checkpoints"):
                 conn.execute(
-                    text(
-                        """
-                        DELETE FROM checkpoint_writes
-                        WHERE thread_id = :thread_id
-                          AND checkpoint_ns = :checkpoint_ns
-                          AND checkpoint_id = :checkpoint_id
-                        """
-                    ),
+                    text(f"DELETE FROM {table} WHERE {where_clause}"),
                     key_params,
                 )
             conn.commit()

--- a/langchain_oceanbase/checkpointer.py
+++ b/langchain_oceanbase/checkpointer.py
@@ -506,6 +506,16 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         """Async version of prune using a thread pool executor."""
         await self._run(self.prune, thread_ids, strategy=strategy)
 
+    async def acopy_thread(
+        self, source_thread_id: str, target_thread_id: str
+    ) -> None:
+        """Async version of copy_thread using a thread pool executor."""
+        await self._run(self.copy_thread, source_thread_id, target_thread_id)
+
+    async def adelete_for_runs(self, run_ids: Sequence[str]) -> None:
+        """Async version of delete_for_runs using a thread pool executor."""
+        await self._run(self.delete_for_runs, run_ids)
+
     def get_tuple(self, config: RunnableConfig) -> Optional[CheckpointTuple]:
         """Get a checkpoint tuple from the database.
 
@@ -1086,6 +1096,153 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
                 text("DELETE FROM checkpoint_writes WHERE thread_id = :thread_id"),
                 {"thread_id": thread_id},
             )
+            conn.commit()
+
+    def copy_thread(self, source_thread_id: str, target_thread_id: str) -> None:
+        """Copy all checkpoints and writes from one thread to another.
+
+        Copies the complete parent chain (every ancestor checkpoint and its
+        blobs and writes), preserving namespaces, ordering, metadata, channel
+        values and pending writes. Only ``thread_id`` is rewritten. If the
+        source thread has no checkpoints this is a no-op.
+
+        Args:
+            source_thread_id: The thread ID to copy from.
+            target_thread_id: The thread ID to copy to.
+
+        Example:
+            .. code-block:: python
+
+                checkpointer.copy_thread("thread-a", "thread-b")
+        """
+        with self._cursor() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO checkpoints
+                    (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id,
+                     `type`, checkpoint, metadata)
+                    SELECT :target_thread_id, checkpoint_ns, checkpoint_id,
+                           parent_checkpoint_id, `type`, checkpoint, metadata
+                    FROM checkpoints
+                    WHERE thread_id = :source_thread_id
+                    """
+                ),
+                {
+                    "source_thread_id": source_thread_id,
+                    "target_thread_id": target_thread_id,
+                },
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO checkpoint_blobs
+                    (thread_id, checkpoint_ns, channel, version, `type`, `blob`)
+                    SELECT :target_thread_id, checkpoint_ns, channel, version,
+                           `type`, `blob`
+                    FROM checkpoint_blobs
+                    WHERE thread_id = :source_thread_id
+                    """
+                ),
+                {
+                    "source_thread_id": source_thread_id,
+                    "target_thread_id": target_thread_id,
+                },
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO checkpoint_writes
+                    (thread_id, checkpoint_ns, checkpoint_id, task_id, task_path,
+                     idx, channel, `type`, `blob`)
+                    SELECT :target_thread_id, checkpoint_ns, checkpoint_id, task_id,
+                           task_path, idx, channel, `type`, `blob`
+                    FROM checkpoint_writes
+                    WHERE thread_id = :source_thread_id
+                    """
+                ),
+                {
+                    "source_thread_id": source_thread_id,
+                    "target_thread_id": target_thread_id,
+                },
+            )
+            conn.commit()
+
+    def delete_for_runs(self, run_ids: Sequence[str]) -> None:
+        """Delete all checkpoints and writes associated with the given run IDs.
+
+        ``run_id`` is stored inside each checkpoint's ``metadata`` JSON (it flows
+        from ``config["metadata"]["run_id"]``). Checkpoints whose metadata
+        ``run_id`` matches are deleted together with their pending writes and
+        channel blobs, across all namespaces. An empty list or unknown run IDs
+        are a no-op.
+
+        Args:
+            run_ids: The run IDs whose checkpoints should be deleted.
+
+        Example:
+            .. code-block:: python
+
+                checkpointer.delete_for_runs(["run-1", "run-2"])
+        """
+        if not run_ids:
+            return
+
+        with self._cursor() as conn:
+            params: Dict[str, Any] = {}
+            placeholders = []
+            for idx, run_id in enumerate(run_ids):
+                key = f"run_id_{idx}"
+                params[key] = run_id
+                placeholders.append(f":{key}")
+            run_id_filter = ", ".join(placeholders)
+
+            # Identify the checkpoints produced by these runs. blobs/writes carry
+            # no run_id, so cascade deletes key off the matched checkpoint rows.
+            matched = self._result_fetchall(
+                conn.execute(
+                    text(
+                        f"""
+                        SELECT thread_id, checkpoint_ns, checkpoint_id
+                        FROM checkpoints
+                        WHERE JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.run_id'))
+                              IN ({run_id_filter})
+                        """
+                    ),
+                    params,
+                )
+            )
+            if not matched:
+                return
+
+            for thread_id, checkpoint_ns, checkpoint_id in matched:
+                key_params = {
+                    "thread_id": thread_id,
+                    "checkpoint_ns": checkpoint_ns,
+                    "checkpoint_id": checkpoint_id,
+                }
+                conn.execute(
+                    text(
+                        """
+                        DELETE FROM checkpoints
+                        WHERE thread_id = :thread_id
+                          AND checkpoint_ns = :checkpoint_ns
+                          AND checkpoint_id = :checkpoint_id
+                        """
+                    ),
+                    key_params,
+                )
+                conn.execute(
+                    text(
+                        """
+                        DELETE FROM checkpoint_writes
+                        WHERE thread_id = :thread_id
+                          AND checkpoint_ns = :checkpoint_ns
+                          AND checkpoint_id = :checkpoint_id
+                        """
+                    ),
+                    key_params,
+                )
             conn.commit()
 
     def prune(

--- a/tests/integration_tests/test_checkpoint_conformance.py
+++ b/tests/integration_tests/test_checkpoint_conformance.py
@@ -126,12 +126,16 @@ async def test_checkpoint_conformance_base() -> None:
             "list",
             "delete_thread",
             "prune",
+            "copy_thread",
+            "delete_for_runs",
         },
         progress=ProgressCallbacks.verbose(),
     )
     report.print_report()
     assert report.passed_all_base()
     assert report.results["prune"].passed is True
+    assert report.results["copy_thread"].passed is True
+    assert report.results["delete_for_runs"].passed is True
 
 
 @pytest.mark.asyncio
@@ -151,12 +155,16 @@ async def test_checkpoint_conformance_oceanbase_server() -> None:
             "list",
             "delete_thread",
             "prune",
+            "copy_thread",
+            "delete_for_runs",
         },
         progress=ProgressCallbacks.verbose(),
     )
     report.print_report()
     assert report.passed_all_base()
     assert report.results["prune"].passed is True
+    assert report.results["copy_thread"].passed is True
+    assert report.results["delete_for_runs"].passed is True
 
 
 @pytest.mark.asyncio
@@ -174,12 +182,16 @@ async def test_checkpoint_conformance_seekdb_server() -> None:
             "list",
             "delete_thread",
             "prune",
+            "copy_thread",
+            "delete_for_runs",
         },
         progress=ProgressCallbacks.verbose(),
     )
     report.print_report()
     assert report.passed_all_base()
     assert report.results["prune"].passed is True
+    assert report.results["copy_thread"].passed is True
+    assert report.results["delete_for_runs"].passed is True
 
 
 @pytest.mark.asyncio
@@ -197,9 +209,13 @@ async def test_checkpoint_conformance_mysql_server() -> None:
             "list",
             "delete_thread",
             "prune",
+            "copy_thread",
+            "delete_for_runs",
         },
         progress=ProgressCallbacks.verbose(),
     )
     report.print_report()
     assert report.passed_all_base()
     assert report.results["prune"].passed is True
+    assert report.results["copy_thread"].passed is True
+    assert report.results["delete_for_runs"].passed is True

--- a/tests/unit_tests/test_checkpointer_async_api.py
+++ b/tests/unit_tests/test_checkpointer_async_api.py
@@ -209,6 +209,43 @@ async def test_aprune_delegates_to_sync_method(
 
 
 @pytest.mark.asyncio
+async def test_acopy_thread_delegates_to_sync_method(
+    saver: OceanBaseCheckpointSaver,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """acopy_thread should delegate to copy_thread."""
+    copy_thread = MagicMock()
+    monkeypatch.setattr(saver, "copy_thread", copy_thread)
+
+    await saver.acopy_thread("source-thread", "target-thread")
+
+    copy_thread.assert_called_once_with("source-thread", "target-thread")
+
+
+@pytest.mark.asyncio
+async def test_adelete_for_runs_delegates_to_sync_method(
+    saver: OceanBaseCheckpointSaver,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """adelete_for_runs should delegate to delete_for_runs."""
+    delete_for_runs = MagicMock()
+    monkeypatch.setattr(saver, "delete_for_runs", delete_for_runs)
+
+    await saver.adelete_for_runs(["run-1", "run-2"])
+
+    delete_for_runs.assert_called_once_with(["run-1", "run-2"])
+
+
+def test_detected_capabilities_include_copy_thread_and_delete_for_runs(
+    saver: OceanBaseCheckpointSaver,
+) -> None:
+    """The saver should advertise the extended copy_thread/delete_for_runs caps."""
+    detected = {cap.value for cap in DetectedCapabilities.from_instance(saver).detected}
+    assert "copy_thread" in detected
+    assert "delete_for_runs" in detected
+
+
+@pytest.mark.asyncio
 async def test_aget_tuple_runs_off_the_event_loop_thread(
     saver: OceanBaseCheckpointSaver,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
Implements the two EXTENDED checkpoint capabilities that `langgraph-checkpoint` 4.x added to `BaseCheckpointSaver` (both raise `NotImplementedError` by default). Closes #156, follow-up to the 4.x bump in #153.

- **`copy_thread(source, target)`** — copies all checkpoints, blobs and writes from one thread to another via `INSERT … SELECT`, rewriting only `thread_id`. Preserves namespaces, ordering, metadata, channel values, the full parent chain and pending writes. Nonexistent source → no-op.
- **`delete_for_runs(run_ids)`** — deletes checkpoints (and their writes) whose stored metadata `run_id` is in `run_ids`, selected via `JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.run_id'))`. Empty/unknown run IDs → no-op; works across namespaces.
- **`acopy_thread` / `adelete_for_runs`** — async wrappers routed through the existing `_run()` thread-pool helper.

## Design notes
- `run_id` is not a column; it lives in the `metadata` JSON (it flows from `config["metadata"]["run_id"]` via `get_checkpoint_metadata`). `delete_for_runs` therefore selects matching checkpoint rows by JSON extraction, then cascades to `checkpoint_writes` by the matched `(thread_id, checkpoint_ns, checkpoint_id)`.
- **Blobs are intentionally not deleted per-checkpoint** in `delete_for_runs`: `checkpoint_blobs` is keyed by `(thread_id, checkpoint_ns, channel, version)` with no `checkpoint_id`, so a blob is shared across checkpoints in a thread. Deleting per-checkpoint would corrupt sibling checkpoints; orphaned content-addressed blobs are harmless and reclaimed by `prune`/`delete_thread`. The conformance spec does not require blob cleanup here.

## Testing
- Enabled `copy_thread` and `delete_for_runs` in all four `test_checkpoint_conformance.py` capability sets, with `report.results[...].passed` assertions.
- **All upstream conformance scenarios pass on embedded SeekDB** (8× `test_copy_thread`, 7× `test_delete_for_runs`); CI will exercise them across embedded-seekdb / seekdb / mysql / oceanbase.
- Added unit tests for the async wrappers (delegation) and updated capability detection.
- Full local run: 119 unit tests pass, conformance passes, ruff clean. (The single mypy warning at the `_existing_index_names` set-comprehension is pre-existing on `develop`, untouched here.)

## Out of scope
`get_delta_channel_history` override — it is beta upstream and the inherited default already works against our `get_tuple`.
