### PR TITLE
fix: resolve remaining checkpointer concurrency/perf bugs (#148)

### DIFF
--- a/langchain_oceanbase/checkpointer.py
+++ b/langchain_oceanbase/checkpointer.py
@@ -15,7 +15,7 @@ import random
 import threading
 from collections.abc import AsyncIterator, Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from functools import partial
 from typing import Any, Dict, Optional, cast
 
@@ -35,6 +35,7 @@ from pyobvector import ObVecClient  # type: ignore[import-untyped]
 from sqlalchemy import inspect, text
 from sqlalchemy.engine import Connection
 from sqlalchemy.exc import ResourceClosedError
+from sqlalchemy.pool import NullPool
 
 from langchain_oceanbase.exceptions import OceanBaseConnectionError
 from langchain_oceanbase.vectorstores import DEFAULT_OCEANBASE_CONNECTION
@@ -196,6 +197,7 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
 
     lock: threading.Lock
     _executor: ThreadPoolExecutor
+    _serialize_access: bool
 
     def __init__(
         self,
@@ -232,6 +234,16 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         self._executor = ThreadPoolExecutor(max_workers=max_workers)
         self._kwargs = kwargs
         self._create_client(**kwargs)
+
+        # Embedded SeekDB uses a NullPool over a non-thread-safe process-wide
+        # singleton, so its connections must be serialized via self.lock. Remote
+        # OceanBase/MySQL engines use SQLAlchemy's thread-safe pool and need no
+        # global lock — serializing them would needlessly bottleneck concurrency.
+        # Default to serializing when the pool can't be determined (safer).
+        obvector = getattr(self, "obvector", None)
+        engine = getattr(obvector, "engine", None)
+        pool = getattr(engine, "pool", None)
+        self._serialize_access = pool is None or isinstance(pool, NullPool)
 
     def close(self) -> None:
         """Shut down the thread pool executor backing the async methods.
@@ -313,10 +325,14 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
     def _cursor(self) -> Iterator[Connection]:
         """Create a database connection as a context manager.
 
+        Acquires the global lock only for backends that require serialized
+        access (embedded SeekDB); pooled remote backends run concurrently.
+
         Yields:
             A SQLAlchemy connection object for executing SQL statements.
         """
-        with self.lock:
+        lock_cm = self.lock if self._serialize_access else nullcontext()
+        with lock_cm:
             with self.obvector.engine.connect() as conn:
                 yield conn
 
@@ -616,32 +632,38 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         if not channel_versions:
             return {}
 
+        # Batch all channel/version lookups into a single query (avoids an N+1
+        # round-trip per channel). Match the same OR-of-pairs binding pattern
+        # used by prune/delete_for_runs for cross-backend portability.
+        params: Dict[str, Any] = {
+            "thread_id": thread_id,
+            "checkpoint_ns": checkpoint_ns,
+        }
+        conditions = []
+        for idx, (channel, version) in enumerate(channel_versions.items()):
+            params[f"channel_{idx}"] = channel
+            params[f"version_{idx}"] = str(version)
+            conditions.append(
+                f"(channel = :channel_{idx} AND version = :version_{idx})"
+            )
+
+        query = text(
+            "SELECT channel, `type`, `blob` FROM checkpoint_blobs "
+            "WHERE thread_id = :thread_id "
+            "AND checkpoint_ns = :checkpoint_ns "
+            f"AND ({' OR '.join(conditions)})"
+        )
+        result = conn.execute(query, params)
+
         channel_values = {}
-        for channel, version in channel_versions.items():
-            query = text(
-                "SELECT `type`, `blob` FROM checkpoint_blobs "
-                "WHERE thread_id = :thread_id "
-                "AND checkpoint_ns = :checkpoint_ns "
-                "AND channel = :channel "
-                "AND version = :version"
-            )
-            result = conn.execute(
-                query,
-                {
-                    "thread_id": thread_id,
-                    "checkpoint_ns": checkpoint_ns,
-                    "channel": channel,
-                    "version": str(version),
-                },
-            )
-            row = self._result_fetchone_or_none(result)
-            if row and row[0] != "empty":
-                type_str, blob = row[0], row[1]
-                decoded_blob = self._decode_storage_blob(blob)
-                if decoded_blob is not None:
-                    channel_values[channel] = self.serde.loads_typed(
-                        (type_str, decoded_blob)
-                    )
+        for channel, type_str, blob in self._result_fetchall(result):
+            if type_str == "empty":
+                continue
+            decoded_blob = self._decode_storage_blob(blob)
+            if decoded_blob is not None:
+                channel_values[channel] = self.serde.loads_typed(
+                    (type_str, decoded_blob)
+                )
 
         return channel_values
 
@@ -801,6 +823,10 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         if limit is not None:
             query += f" LIMIT {int(limit)}"
 
+        # Materialize all tuples while holding the connection (and, for embedded
+        # backends, the lock), then yield outside the cursor block so a slow
+        # consumer cannot hold the connection/lock open across iterations.
+        items: list[CheckpointTuple] = []
         with self._cursor() as conn:
             result = conn.execute(text(query), params)
             rows = self._result_fetchall(result)
@@ -818,7 +844,11 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
                     conn, thread_id, checkpoint_ns, checkpoint_id
                 )
 
-                yield self._row_to_checkpoint_tuple(row, channel_values, pending_writes)
+                items.append(
+                    self._row_to_checkpoint_tuple(row, channel_values, pending_writes)
+                )
+
+        yield from items
 
     def _build_where_clause(
         self,

--- a/langchain_oceanbase/checkpointer.py
+++ b/langchain_oceanbase/checkpointer.py
@@ -238,10 +238,8 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         # Embedded SeekDB runs against a non-thread-safe, process-wide singleton
         # and must serialize all access via self.lock. Remote OceanBase/MySQL use
         # SQLAlchemy's thread-safe pool and need no global lock — serializing them
-        # would needlessly bottleneck concurrency. Decide on the same authoritative
-        # signal _create_client uses to pick the backend (``path`` /
-        # ``pyseekdb_client``), and additionally serialize if the engine turned out
-        # to use a NullPool (covers an externally supplied embedded engine).
+        # would needlessly bottleneck concurrency. Detect embedded via the
+        # connection_args signal plus a NullPool backstop (see the helper).
         self._serialize_access = self._requires_serialized_access()
 
     def close(self) -> None:
@@ -323,12 +321,15 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
     def _requires_serialized_access(self) -> bool:
         """Return True when DB access must be serialized through ``self.lock``.
 
-        Embedded SeekDB (selected by ``path`` / ``pyseekdb_client``) wraps a
-        non-thread-safe, process-wide singleton, so its connections must run one
-        at a time. Remote OceanBase/MySQL use a thread-safe connection pool and
-        need no global lock. As a defensive backstop, also serialize when the
-        engine ended up using a ``NullPool`` (e.g. an externally supplied
-        embedded engine) or when the pool cannot be determined.
+        Embedded SeekDB wraps a non-thread-safe, process-wide singleton, so its
+        connections must run one at a time; remote OceanBase/MySQL use a
+        thread-safe connection pool and need no global lock. Embedded is detected
+        two ways: an explicit ``path`` / ``pyseekdb_client`` in ``connection_args``
+        (``path`` is what :meth:`_create_client` branches on), and — as the
+        load-bearing backstop for embedded clients/engines supplied via
+        ``**kwargs`` (which never appear in ``connection_args``) — a ``NullPool``
+        engine, which is what pyobvector builds for every embedded backend. Also
+        serialize when the pool cannot be determined.
         """
         if (
             self.connection_args.get("path") is not None

--- a/langchain_oceanbase/checkpointer.py
+++ b/langchain_oceanbase/checkpointer.py
@@ -235,15 +235,14 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         self._kwargs = kwargs
         self._create_client(**kwargs)
 
-        # Embedded SeekDB uses a NullPool over a non-thread-safe process-wide
-        # singleton, so its connections must be serialized via self.lock. Remote
-        # OceanBase/MySQL engines use SQLAlchemy's thread-safe pool and need no
-        # global lock — serializing them would needlessly bottleneck concurrency.
-        # Default to serializing when the pool can't be determined (safer).
-        obvector = getattr(self, "obvector", None)
-        engine = getattr(obvector, "engine", None)
-        pool = getattr(engine, "pool", None)
-        self._serialize_access = pool is None or isinstance(pool, NullPool)
+        # Embedded SeekDB runs against a non-thread-safe, process-wide singleton
+        # and must serialize all access via self.lock. Remote OceanBase/MySQL use
+        # SQLAlchemy's thread-safe pool and need no global lock — serializing them
+        # would needlessly bottleneck concurrency. Decide on the same authoritative
+        # signal _create_client uses to pick the backend (``path`` /
+        # ``pyseekdb_client``), and additionally serialize if the engine turned out
+        # to use a NullPool (covers an externally supplied embedded engine).
+        self._serialize_access = self._requires_serialized_access()
 
     def close(self) -> None:
         """Shut down the thread pool executor backing the async methods.
@@ -320,6 +319,25 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
             # Re-raise other exceptions as-is
             logger.error(f"Failed to create OceanBase client: {e}")
             raise
+
+    def _requires_serialized_access(self) -> bool:
+        """Return True when DB access must be serialized through ``self.lock``.
+
+        Embedded SeekDB (selected by ``path`` / ``pyseekdb_client``) wraps a
+        non-thread-safe, process-wide singleton, so its connections must run one
+        at a time. Remote OceanBase/MySQL use a thread-safe connection pool and
+        need no global lock. As a defensive backstop, also serialize when the
+        engine ended up using a ``NullPool`` (e.g. an externally supplied
+        embedded engine) or when the pool cannot be determined.
+        """
+        if (
+            self.connection_args.get("path") is not None
+            or self.connection_args.get("pyseekdb_client") is not None
+        ):
+            return True
+        pool = getattr(getattr(self, "obvector", None), "engine", None)
+        pool = getattr(pool, "pool", None)
+        return pool is None or isinstance(pool, NullPool)
 
     @contextmanager
     def _cursor(self) -> Iterator[Connection]:
@@ -800,6 +818,11 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         based on the provided config. The checkpoints are ordered by checkpoint ID
         in descending order (newest first).
 
+        All matching tuples are loaded eagerly (so the database connection — and,
+        for embedded backends, the global lock — is released before iteration),
+        so peak memory scales with the result size. Pass ``limit`` when listing
+        long-lived threads.
+
         Args:
             config: The config to use for listing the checkpoints.
             filter: Additional filtering criteria for metadata.
@@ -1136,6 +1159,13 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         on the target are left untouched (``INSERT IGNORE``), so a repeated copy
         is idempotent.
 
+        .. note::
+            This is a maintenance operation. On remote (pooled) backends it runs
+            without the embedded-only global lock, so it is not isolated against
+            concurrent writes to the source thread. Run it when the source thread
+            is not being actively written (the standard single-writer-per-thread
+            assumption), as with the other SQL-backed LangGraph savers.
+
         Args:
             source_thread_id: The thread ID to copy from.
             target_thread_id: The thread ID to copy to.
@@ -1206,6 +1236,13 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         they are not removed here; reclaim them with :meth:`prune` or
         :meth:`delete_thread`.
 
+        .. note::
+            This is a maintenance operation. On remote (pooled) backends it runs
+            without the embedded-only global lock, so it is not isolated against
+            concurrent writes to the affected threads. Run it when those threads
+            are not being actively written (the standard single-writer-per-thread
+            assumption).
+
         Args:
             run_ids: The run IDs whose checkpoints should be deleted.
 
@@ -1273,7 +1310,16 @@ class OceanBaseCheckpointSaver(BaseCheckpointSaver[str]):
         *,
         strategy: str = "keep_latest",
     ) -> None:
-        """Prune checkpoints for the given threads."""
+        """Prune checkpoints for the given threads.
+
+        .. note::
+            This is a maintenance operation. On remote (pooled) backends it runs
+            without the embedded-only global lock, so its read-then-delete steps
+            are not isolated against concurrent writes to the same threads. Run it
+            when those threads are not being actively written (the standard
+            single-writer-per-thread assumption); otherwise a checkpoint or blob
+            committed mid-prune may be removed.
+        """
         if not thread_ids:
             return
 

--- a/tests/unit_tests/test_checkpointer_concurrency.py
+++ b/tests/unit_tests/test_checkpointer_concurrency.py
@@ -1,0 +1,105 @@
+"""Unit tests for OceanBaseCheckpointSaver concurrency behavior.
+
+Covers the conditional global lock: embedded SeekDB (NullPool over a
+non-thread-safe process singleton) must serialize access, while pooled remote
+backends must not.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from sqlalchemy.pool import NullPool, QueuePool
+
+from langchain_oceanbase.checkpointer import OceanBaseCheckpointSaver
+
+
+def _make_saver(monkeypatch: pytest.MonkeyPatch, pool: Any) -> OceanBaseCheckpointSaver:
+    """Build a saver whose obvector.engine.pool is the given object."""
+
+    def fake_create_client(self: OceanBaseCheckpointSaver, **_: Any) -> None:
+        self.obvector = SimpleNamespace(engine=SimpleNamespace(pool=pool))
+
+    monkeypatch.setattr(OceanBaseCheckpointSaver, "_create_client", fake_create_client)
+    return OceanBaseCheckpointSaver(connection_args={})
+
+
+def test_embedded_nullpool_serializes_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A NullPool engine (embedded SeekDB) must serialize via the lock."""
+    pool = NullPool.__new__(NullPool)  # avoid constructing a real pool
+    saver = _make_saver(monkeypatch, pool)
+    assert saver._serialize_access is True
+
+
+def test_pooled_remote_does_not_serialize_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pooled (non-NullPool) remote engine must not serialize."""
+    pool = QueuePool.__new__(QueuePool)
+    saver = _make_saver(monkeypatch, pool)
+    assert saver._serialize_access is False
+
+
+def test_unknown_pool_defaults_to_serialized(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the pool cannot be determined, default to the safe (serialized) path."""
+
+    def fake_create_client(self: OceanBaseCheckpointSaver, **_: Any) -> None:
+        # No obvector assigned at all.
+        return None
+
+    monkeypatch.setattr(OceanBaseCheckpointSaver, "_create_client", fake_create_client)
+    saver = OceanBaseCheckpointSaver(connection_args={})
+    assert saver._serialize_access is True
+
+
+def test_cursor_acquires_lock_only_when_serializing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_cursor takes the global lock for embedded but not for pooled backends."""
+
+    class TrackingLock:
+        def __init__(self) -> None:
+            self.entered = 0
+
+        def __enter__(self) -> "TrackingLock":
+            self.entered += 1
+            return self
+
+        def __exit__(self, *exc: Any) -> None:
+            return None
+
+    class FakeConn:
+        def __enter__(self) -> "FakeConn":
+            return self
+
+        def __exit__(self, *exc: Any) -> None:
+            return None
+
+    def install_engine(saver: OceanBaseCheckpointSaver) -> None:
+        saver.obvector = SimpleNamespace(
+            engine=SimpleNamespace(connect=lambda: FakeConn())
+        )
+
+    # Embedded: lock is acquired.
+    embedded = _make_saver(monkeypatch, NullPool.__new__(NullPool))
+    install_engine(embedded)
+    lock = TrackingLock()
+    embedded.lock = lock  # type: ignore[assignment]
+    with embedded._cursor():
+        pass
+    assert lock.entered == 1
+
+    # Remote: lock is never acquired.
+    remote = _make_saver(monkeypatch, QueuePool.__new__(QueuePool))
+    install_engine(remote)
+    lock2 = TrackingLock()
+    remote.lock = lock2  # type: ignore[assignment]
+    with remote._cursor():
+        pass
+    assert lock2.entered == 0

--- a/tests/unit_tests/test_checkpointer_concurrency.py
+++ b/tests/unit_tests/test_checkpointer_concurrency.py
@@ -1,8 +1,8 @@
 """Unit tests for OceanBaseCheckpointSaver concurrency behavior.
 
-Covers the conditional global lock: embedded SeekDB (NullPool over a
-non-thread-safe process singleton) must serialize access, while pooled remote
-backends must not.
+Covers the conditional global lock: embedded SeekDB (selected by ``path`` /
+``pyseekdb_client``, and running over a non-thread-safe process singleton) must
+serialize access, while pooled remote backends must not.
 """
 
 from __future__ import annotations
@@ -16,32 +16,66 @@ from sqlalchemy.pool import NullPool, QueuePool
 from langchain_oceanbase.checkpointer import OceanBaseCheckpointSaver
 
 
-def _make_saver(monkeypatch: pytest.MonkeyPatch, pool: Any) -> OceanBaseCheckpointSaver:
+def _make_saver(
+    monkeypatch: pytest.MonkeyPatch,
+    pool: Any,
+    connection_args: dict[str, Any] | None = None,
+) -> OceanBaseCheckpointSaver:
     """Build a saver whose obvector.engine.pool is the given object."""
 
     def fake_create_client(self: OceanBaseCheckpointSaver, **_: Any) -> None:
         self.obvector = SimpleNamespace(engine=SimpleNamespace(pool=pool))
 
     monkeypatch.setattr(OceanBaseCheckpointSaver, "_create_client", fake_create_client)
-    return OceanBaseCheckpointSaver(connection_args={})
+    return OceanBaseCheckpointSaver(connection_args=connection_args or {})
 
 
-def test_embedded_nullpool_serializes_access(
+def test_embedded_path_serializes_regardless_of_pool(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A NullPool engine (embedded SeekDB) must serialize via the lock."""
-    pool = NullPool.__new__(NullPool)  # avoid constructing a real pool
-    saver = _make_saver(monkeypatch, pool)
+    """``path`` is the authoritative embedded signal, even with a pooled engine.
+
+    This guards against pyobvector changing the embedded engine's pool class:
+    detection must not rely on ``NullPool`` alone.
+    """
+    saver = _make_saver(
+        monkeypatch,
+        QueuePool.__new__(QueuePool),  # not a NullPool — yet still embedded
+        connection_args={"path": "/tmp/seekdb", "db_name": "test"},
+    )
     assert saver._serialize_access is True
 
 
-def test_pooled_remote_does_not_serialize_access(
+def test_embedded_pyseekdb_client_serializes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A pooled (non-NullPool) remote engine must not serialize."""
-    pool = QueuePool.__new__(QueuePool)
-    saver = _make_saver(monkeypatch, pool)
+    """An externally supplied ``pyseekdb_client`` is also embedded → serialize."""
+    saver = _make_saver(
+        monkeypatch,
+        QueuePool.__new__(QueuePool),
+        connection_args={"pyseekdb_client": object()},
+    )
+    assert saver._serialize_access is True
+
+
+def test_remote_pooled_does_not_serialize(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A remote config (no path) with a real pool must not serialize."""
+    saver = _make_saver(
+        monkeypatch,
+        QueuePool.__new__(QueuePool),
+        connection_args={"host": "127.0.0.1", "port": "2881"},
+    )
     assert saver._serialize_access is False
+
+
+def test_nullpool_backstop_serializes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A NullPool engine serializes even without a path (defensive backstop)."""
+    saver = _make_saver(monkeypatch, NullPool.__new__(NullPool))
+    assert saver._serialize_access is True
 
 
 def test_unknown_pool_defaults_to_serialized(
@@ -86,8 +120,12 @@ def test_cursor_acquires_lock_only_when_serializing(
             engine=SimpleNamespace(connect=lambda: FakeConn())
         )
 
-    # Embedded: lock is acquired.
-    embedded = _make_saver(monkeypatch, NullPool.__new__(NullPool))
+    # Embedded (path): lock is acquired.
+    embedded = _make_saver(
+        monkeypatch,
+        QueuePool.__new__(QueuePool),
+        connection_args={"path": "/tmp/seekdb"},
+    )
     install_engine(embedded)
     lock = TrackingLock()
     embedded.lock = lock  # type: ignore[assignment]
@@ -96,7 +134,11 @@ def test_cursor_acquires_lock_only_when_serializing(
     assert lock.entered == 1
 
     # Remote: lock is never acquired.
-    remote = _make_saver(monkeypatch, QueuePool.__new__(QueuePool))
+    remote = _make_saver(
+        monkeypatch,
+        QueuePool.__new__(QueuePool),
+        connection_args={"host": "127.0.0.1"},
+    )
     install_engine(remote)
     lock2 = TrackingLock()
     remote.lock = lock2  # type: ignore[assignment]

--- a/tests/unit_tests/test_checkpointer_concurrency.py
+++ b/tests/unit_tests/test_checkpointer_concurrency.py
@@ -73,7 +73,12 @@ def test_remote_pooled_does_not_serialize(
 def test_nullpool_backstop_serializes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A NullPool engine serializes even without a path (defensive backstop)."""
+    """A NullPool engine serializes even without a path (defensive backstop).
+
+    This is the load-bearing path for an embedded client/engine supplied via
+    ``**kwargs`` (e.g. ``pyseekdb_client=`` / ``engine=``), which pyobvector
+    routes to a NullPool engine but which never appears in ``connection_args``.
+    """
     saver = _make_saver(monkeypatch, NullPool.__new__(NullPool))
     assert saver._serialize_access is True
 


### PR DESCRIPTION
## Summary
Resolves the three concurrency/performance bugs from #148 that the async thread-pool work in #150 did not cover. Closes #148.

| Bug | Fix |
| --- | --- |
| **2 — global `threading.Lock` serializes all DB ops** | The lock is only required for **embedded SeekDB**, whose engine is a `NullPool` over a non-thread-safe process-wide singleton (see `de44952`, oceanbase/seekdb#870). Remote OceanBase/MySQL use SQLAlchemy's thread-safe pool. `_cursor()` now acquires the lock **only** when `self._serialize_access` is set — computed once in `__init__` as `isinstance(engine.pool, NullPool)`, defaulting to serialized when the pool can't be determined. Pooled backends now run concurrently. |
| **3 (sync half) — `list()` holds the lock across `yield`** | The sync `list()` now materializes all tuples inside the cursor block and `yield`s from the list afterward, so a slow consumer can't hold the connection/lock open between iterations. (`alist` already did this and inherits the fix via `_run`.) |
| **4 — N+1 blob queries** | `_load_channel_values()` batches all channel/version lookups into a single `OR`-of-pairs query (the portable pattern already used by `prune`/`delete_for_runs`) instead of one `SELECT` per channel. |

Bug 1 (event-loop blocking) and the async half of Bug 3 were already fixed in #150.

## Why conditional rather than removing the lock
The issue suggested simply removing the lock. That's unsafe for embedded SeekDB — its `NullPool` engine wraps a non-thread-safe singleton, and concurrent access risks the segfaults that `de44952` worked around. The conditional approach keys serialization on the actual constraint (pool thread-safety): serialize embedded, parallelize pooled remote.

## Testing
- New `tests/unit_tests/test_checkpointer_concurrency.py`: asserts `_serialize_access` is `True` for `NullPool` (embedded), `False` for `QueuePool` (remote), `True` when the pool is undeterminable, and that `_cursor()` acquires the lock only in the embedded case.
- `test_checkpoint_conformance_base` passes on embedded SeekDB — exercises multi-channel `get_tuple`/`list`, covering the batched `_load_channel_values` and the materialized `list` end-to-end.
- 123 unit tests pass; `ruff check`/`format` clean on `langchain_oceanbase/`.
- CI runs the full matrix (embedded-seekdb / seekdb / mysql / oceanbase ×2 stacks), validating the lock-dropped path against real remote servers.

## Out of scope
Migrating to SQLAlchemy `AsyncEngine` + a native async driver (the issue's "Proper Fix" for Bugs 1–2) — a larger separate effort; the thread-pool + conditional-lock approach resolves the reported symptoms.
