### PR TITLE
build: bump pylibseekdb to 1.3.0.post4

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3135,22 +3135,19 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pylibseekdb"
-version = "1.3.0.post3"
+version = "1.3.0.post4"
 description = "Python bindings for the seekdb C client"
 optional = true
 python-versions = ">=3.11"
 groups = ["main"]
 markers = "(sys_platform == \"linux\" or sys_platform == \"darwin\" and platform_machine == \"arm64\") and extra == \"pyseekdb\""
 files = [
-    {file = "pylibseekdb-1.3.0.post3-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:e89ce984e3222f5af7cb276510f208c07dfdf89c3a812b8ee56b86f869685e0e"},
-    {file = "pylibseekdb-1.3.0.post3-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da1f1e8ae274281a2fb93505f688525ec50a4c02c680ebbe384313bf65862b3a"},
-    {file = "pylibseekdb-1.3.0.post3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:514ba51eeff4a982d015c938f605ec9782aa7eedf0040af0e6adc102bd565417"},
-    {file = "pylibseekdb-1.3.0.post3-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:58cbe0c4ed609fc67f9012760c5529858ceebe96fd79a4042cddf52b7ea4813e"},
-    {file = "pylibseekdb-1.3.0.post3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fadcf644e9d1187f04d671816ac0ddb0ae88018fefd53b40eee2f81ee509bb97"},
-    {file = "pylibseekdb-1.3.0.post3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5733828a73f9723e84cf9ca318b228e7a9bf3c66b4684e08701373a438d087c7"},
-    {file = "pylibseekdb-1.3.0.post3-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:ba5e515340988e4d8906ac386497cbab0849c3ecbe5d782fd72093f4d208f94e"},
-    {file = "pylibseekdb-1.3.0.post3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aaee77db55170af5fe32a8fde4041dc3f3bf2648f25a254c2742eaa6599fad5b"},
-    {file = "pylibseekdb-1.3.0.post3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:b57df3dabce5c80bf2230db2dc3f55b8eb6807a79b0884c748c0380aa34aa466"},
+    {file = "pylibseekdb-1.3.0.post4-cp311-cp311-macosx_15_0_arm64.whl", hash = "sha256:6b81347bb6358cbbc285034bf8c90efe6c2e7271d44a3662c783ee3082612716"},
+    {file = "pylibseekdb-1.3.0.post4-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:2e59856d1f994ba9c32a58c47f368b0e271127e92e4e47f8831a3093147068ea"},
+    {file = "pylibseekdb-1.3.0.post4-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:5d6934330d218c4e3edf9d2ec9cb339f6c0a73c587883edb58c90904f6f2d6e7"},
+    {file = "pylibseekdb-1.3.0.post4-cp312-abi3-macosx_15_0_arm64.whl", hash = "sha256:1365f13dab633eadb2f8f305f8af638adacc5bfb9e71abd877190476d30d1589"},
+    {file = "pylibseekdb-1.3.0.post4-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5052794da997f3311f9b57c0bf29d492bf184118fe03829df74975bce7beecf5"},
+    {file = "pylibseekdb-1.3.0.post4-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ee2700b5990e5e4f11c4b980b182cf7b066817ddd91c7b876152b88a7c24a7ea"},
 ]
 
 [[package]]
@@ -4841,4 +4838,4 @@ pyseekdb = ["pylibseekdb", "pyseekdb"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<3.14"
-content-hash = "1d11948ebfa37c417e5728ab0ae673ddf231c9528baf5557619c399c63f82142"
+content-hash = "39299cec6969c092da847dd80ee25abf9f1b27a2780dfae20ccf7c1f19fd8772"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,10 @@ langgraph-checkpoint = ">=4.0.0,<5.0.0"
 # >=1.2: unified SeekDB client. Constrain pylibseekdb so the lock resolves to 1.1+ (manylinux + macOS arm64 wheels);
 # 1.0.0.post1 is Linux-wheel-only metadata and breaks Poetry on macOS arm64 / some CI installers.
 pyseekdb = { version = ">=1.2.0.post1,<3", optional = true }
-# >=1.3: fixes segfault in embedded mode when data dirs are reused (oceanbase/seekdb#870).
-# !=1.3.0.post1: that post-release wires a per-connection close()->_cleanup() into
-# pyobvector's NullPool embedded engine, tearing down the shared process-wide SeekDB
-# singleton after every query and hanging the checkpointer (see oceanbase/pyobvector
-# tracking issue). Re-allow once pyobvector exposes a one-shot disposal seam.
-pylibseekdb = { version = ">=1.3.0,!=1.3.0.post1,<2", optional = true, markers = "sys_platform == 'linux' or (sys_platform == 'darwin' and platform_machine == 'arm64')" }
+# >=1.3.0.post4: stable release with the Unix-socket support required by native
+# async drivers (oceanbase/langchain-oceanbase#151), while retaining the embedded
+# data-directory reuse fix introduced in 1.3.0 (oceanbase/seekdb#870).
+pylibseekdb = { version = ">=1.3.0.post4,<2", optional = true, markers = "sys_platform == 'linux' or (sys_platform == 'darwin' and platform_machine == 'arm64')" }
 pyobvector = [
     { version = ">=0.2.29" },
     { version = ">=0.2.29", extras = ["pyseekdb"], markers = "extra == 'pyseekdb'" },


### PR DESCRIPTION
## Summary

- require `pylibseekdb>=1.3.0.post4,<2` for the optional embedded seekdb extra
- refresh `poetry.lock` from pylibseekdb 1.3.0.post3 to the stable post4 wheels
- document that post4 carries the Unix-socket support tracked in #151

## Why

Issue #151 verified native async-driver access against the pre-release build. Version 1.3.0.post4 is now the latest stable pylibseekdb release, so the integration should consume the stable artifact instead of leaving resolution at post3.

Related to #151.

## Validation

- `poetry check --lock`
- exact Python 3.12 install reports `pylibseekdb=1.3.0.post4`
- `ruff check langchain_oceanbase/`
- `ruff format langchain_oceanbase/ --check`
- unit suite: 125 passed, 2 skipped
- `poetry build` (sdist and wheel)

Local macOS 15.7 ARM64 embedded initialization remained blocked before the first integration assertion; the hosted Linux embedded matrix is the required platform validation for this native dependency.